### PR TITLE
Ft update tutorial readme

### DIFF
--- a/tutorials/distributed-ml/torch-tutorial-0-basics/README.md
+++ b/tutorials/distributed-ml/torch-tutorial-0-basics/README.md
@@ -74,8 +74,8 @@ srun --jobid XXXX --ntasks-per-node=1 horovodrun -np 4 -H localhost:4 python -u 
 
 ## Distributed training with SLURM (batch mode)
 
-Before running any of the commands below independently, for the first time, 
-ensure you have created the `logs_slurm` folder to ensure output and error files are stored correctly. 
+Before running any of the commands below independently, for the first time,
+ensure you have created the `logs_slurm` folder to ensure output and error files are stored correctly.
 Ignore this step if you are to execute the `runall.sh` script as it creates the folder.
 
 Each distributed strategy has its own SLURM job script, which

--- a/tutorials/distributed-ml/torch-tutorial-0-basics/README.md
+++ b/tutorials/distributed-ml/torch-tutorial-0-basics/README.md
@@ -74,7 +74,9 @@ srun --jobid XXXX --ntasks-per-node=1 horovodrun -np 4 -H localhost:4 python -u 
 
 ## Distributed training with SLURM (batch mode)
 
-Before running any of the commands below independently, for the first time, ensure you have created the `logs_slurm` folder to ensure output and error files are stored correctly. Ignore this step if you are to execute the `runall.sh` script as it creates the folder. 
+Before running any of the commands below independently, for the first time, 
+ensure you have created the `logs_slurm` folder to ensure output and error files are stored correctly. 
+Ignore this step if you are to execute the `runall.sh` script as it creates the folder.
 
 Each distributed strategy has its own SLURM job script, which
 should be used to run it:

--- a/tutorials/distributed-ml/torch-tutorial-0-basics/README.md
+++ b/tutorials/distributed-ml/torch-tutorial-0-basics/README.md
@@ -74,6 +74,8 @@ srun --jobid XXXX --ntasks-per-node=1 horovodrun -np 4 -H localhost:4 python -u 
 
 ## Distributed training with SLURM (batch mode)
 
+Before running any of the commands below independently, for the first time, ensure you have created the `logs_slurm` folder to ensure output and error files are stored correctly. Ignore this step if you are to execute the `runall.sh` script as it creates the folder. 
+
 Each distributed strategy has its own SLURM job script, which
 should be used to run it:
 

--- a/tutorials/distributed-ml/torch-tutorial-1-mnist/README.md
+++ b/tutorials/distributed-ml/torch-tutorial-1-mnist/README.md
@@ -27,6 +27,8 @@ This command creates a local folder called "MNIST" with the dataset.
 
 ## Distributed training
 
+Before running any of the commands below independently, for the first time, ensure you have created the `logs_slurm` folder to ensure output and error files are stored correctly. Ignore this step if you are to execute the `runall.sh` script as it creates the folder. 
+
 Each distributed strategy has its own SLURM job script, which
 should be used to run it:
 

--- a/tutorials/distributed-ml/torch-tutorial-1-mnist/README.md
+++ b/tutorials/distributed-ml/torch-tutorial-1-mnist/README.md
@@ -27,7 +27,9 @@ This command creates a local folder called "MNIST" with the dataset.
 
 ## Distributed training
 
-Before running any of the commands below independently, for the first time, ensure you have created the `logs_slurm` folder to ensure output and error files are stored correctly. Ignore this step if you are to execute the `runall.sh` script as it creates the folder. 
+Before running any of the commands below independently, for the first time,
+ensure you have created the `logs_slurm` folder to ensure output and error files are stored correctly.
+Ignore this step if you are to execute the `runall.sh` script as it creates the folder.
 
 Each distributed strategy has its own SLURM job script, which
 should be used to run it:


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary
- This PR updates the tutorial documentation for the distributed PyTorch mnist models (0 & 1 examples) by adding an instruction to guide a user to create the results folder `logs_slurm` before running the slurm jobs independently.
<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
- None.
