### PR TITLE
Distributed print decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "ipykernel",
     "ipython",
+    "isort",
     "tensorflow==2.16.*",  # needed by tests on tensorboard
 ]
 

--- a/src/itwinai/components.py
+++ b/src/itwinai/components.py
@@ -94,7 +94,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from .distributed import (
     builtin_print,
     detect_distributed_environment,
-    distributed_patch_print
+    distributed_patch_print,
 )
 from .serialization import ModelLoader, Serializable
 from .type import MLArtifact, MLDataset, MLModel

--- a/src/itwinai/components.py
+++ b/src/itwinai/components.py
@@ -116,46 +116,6 @@ def monitor_exec(method: Callable) -> Callable:
         return result
     return wrapper
 
-# def monitor_exec(print_on_main_worker_only: bool = False) -> Callable:
-#     """Decorator for execute method of a component class.
-#     Computes execution time and gives some information about
-#     the execution of the component.
-
-#     Args:
-#         print_on_main_worker_only (bool): whether to ignore ``print()`` calls on
-#             workers which are not the main worker in a distributed context,
-#             such as distributed ML. If set to ``True``, to force printing on
-#             all workers you will need to use ``print(..., force=True)``.
-#     """
-
-#     def method_decorator(method: Callable) -> Callable:
-#         @functools.wraps(method)
-#         def wrapper(self: BaseComponent, *args, **kwargs) -> Any:
-#             if print_on_main_worker_only:
-#                 # Disable print in workers different from the main one,
-#                 # when in distributed environments.
-#                 dist_grank = detect_distributed_environment().global_rank
-#                 patched_print = distributed_patch_print(is_main=dist_grank == 0)
-#                 __builtin__.print = patched_print
-
-#             msg = f"Starting execution of '{self.name}'..."
-#             self._printout(msg)
-#             start_t = time.time()
-#             try:
-#                 result = method(self, *args, **kwargs)
-#             finally:
-#                 self.cleanup()
-#             self.exec_t = time.time() - start_t
-#             msg = f"'{self.name}' executed in {self.exec_t:.3f}s"
-#             self._printout(msg)
-
-#             # Reset print() to __builtins__ one
-#             __builtin__.print = builtin_print
-
-#             return result
-#         return wrapper
-#     return method_decorator
-
 
 class BaseComponent(ABC, Serializable):
     """Base component class. Each component provides a simple interface

--- a/src/itwinai/components.py
+++ b/src/itwinai/components.py
@@ -95,38 +95,50 @@ from .type import MLModel, MLDataset, MLArtifact
 from .serialization import ModelLoader, Serializable
 from .distributed import (
     detect_distributed_environment,
-    distributed_patch_print
+    distributed_patch_print,
+    builtin_print
 )
 
 
-def monitor_exec(method: Callable) -> Callable:
+def monitor_exec(print_on_main_worker_only: bool = False) -> Callable:
     """Decorator for execute method of a component class.
     Computes execution time and gives some information about
     the execution of the component.
 
     Args:
-        func (Callable): class method.
+        print_on_main_worker_only (bool): whether to ignore ``print()`` calls on
+            workers which are not the main worker in a distributed context,
+            such as distributed ML. If set to ``True``, to force printing on
+            all workers you will need to use ``print(..., force=True)``.
     """
-    @functools.wraps(method)
-    def monitored_method(self: BaseComponent, *args, **kwargs) -> Any:
-        # # Disable print in workers different from the main one,
-        # # when in distributed environments.
-        # dist_grank = detect_distributed_environment().global_rank
-        # distributed_patch_print(is_main=dist_grank == 0)
 
-        msg = f"Starting execution of '{self.name}'..."
-        self._printout(msg)
-        start_t = time.time()
-        try:
-            result = method(self, *args, **kwargs)
-        finally:
-            self.cleanup()
-        self.exec_t = time.time() - start_t
-        msg = f"'{self.name}' executed in {self.exec_t:.3f}s"
-        self._printout(msg)
-        return result
+    def method_decorator(method: Callable) -> Callable:
+        @functools.wraps(method)
+        def wrapper(self: BaseComponent, *args, **kwargs) -> Any:
+            if print_on_main_worker_only:
+                # Disable print in workers different from the main one,
+                # when in distributed environments.
+                dist_grank = detect_distributed_environment().global_rank
+                distributed_patch_print(is_main=dist_grank == 0)
 
-    return monitored_method
+            msg = f"Starting execution of '{self.name}'..."
+            self._printout(msg)
+            start_t = time.time()
+            try:
+                result = method(self, *args, **kwargs)
+            finally:
+                self.cleanup()
+            self.exec_t = time.time() - start_t
+            msg = f"'{self.name}' executed in {self.exec_t:.3f}s"
+            self._printout(msg)
+
+            # Reset print() to __builtins__ one
+            __builtin__.print = builtin_print
+
+            return result
+
+        return wrapper
+    return method_decorator
 
 
 class BaseComponent(ABC, Serializable):

--- a/src/itwinai/components.py
+++ b/src/itwinai/components.py
@@ -95,8 +95,7 @@ from .type import MLArtifact, MLDataset, MLModel
 
 
 def monitor_exec(method: Callable) -> Callable:
-    """
-    Decorator for ``BaseComponent``'s methods.
+    """Decorator for ``BaseComponent``'s methods.
     Prints when the component starts and ends executing, indicating
     its execution time.
     """

--- a/src/itwinai/components.py
+++ b/src/itwinai/components.py
@@ -88,6 +88,7 @@ from typing import Any, Optional, Tuple, Union, Callable, Dict, List
 from abc import ABC, abstractmethod
 import time
 import functools
+import builtins as __builtin__
 # import logging
 # from logging import Logger as PythonLogger
 

--- a/src/itwinai/components.py
+++ b/src/itwinai/components.py
@@ -84,21 +84,20 @@ Example:
 
 
 from __future__ import annotations
-from typing import Any, Optional, Tuple, Union, Callable, Dict, List
-from abc import ABC, abstractmethod
-import time
-import functools
-import builtins as __builtin__
-# import logging
-# from logging import Logger as PythonLogger
 
-from .type import MLModel, MLDataset, MLArtifact
-from .serialization import ModelLoader, Serializable
+import builtins as __builtin__
+import functools
+import time
+from abc import ABC, abstractmethod
+from typing import Any, Optional, Tuple, Union, Callable, Dict, List
+
 from .distributed import (
     detect_distributed_environment,
     distributed_patch_print,
     builtin_print
 )
+from .serialization import ModelLoader, Serializable
+from .type import MLModel, MLDataset, MLArtifact
 
 
 def monitor_exec(print_on_main_worker_only: bool = False) -> Callable:

--- a/src/itwinai/components.py
+++ b/src/itwinai/components.py
@@ -109,10 +109,10 @@ def monitor_exec(method: Callable) -> Callable:
     """
     @functools.wraps(method)
     def monitored_method(self: BaseComponent, *args, **kwargs) -> Any:
-        # Disable print in workers different from the main one,
-        # when in distributed environments.
-        dist_grank = detect_distributed_environment().global_rank
-        distributed_patch_print(is_main=dist_grank == 0)
+        # # Disable print in workers different from the main one,
+        # # when in distributed environments.
+        # dist_grank = detect_distributed_environment().global_rank
+        # distributed_patch_print(is_main=dist_grank == 0)
 
         msg = f"Starting execution of '{self.name}'..."
         self._printout(msg)

--- a/src/itwinai/components.py
+++ b/src/itwinai/components.py
@@ -118,8 +118,6 @@ def monitor_exec(method: Callable) -> Callable:
         self._printout(msg)
         start_t = time.time()
         try:
-            # print(f'ARGS: {args}')
-            # print(f'KWARGS: {kwargs}')
             result = method(self, *args, **kwargs)
         finally:
             self.cleanup()

--- a/src/itwinai/components.py
+++ b/src/itwinai/components.py
@@ -89,15 +89,15 @@ import builtins as __builtin__
 import functools
 import time
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Tuple, Union, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from .distributed import (
+    builtin_print,
     detect_distributed_environment,
-    distributed_patch_print,
-    builtin_print
+    distributed_patch_print
 )
 from .serialization import ModelLoader, Serializable
-from .type import MLModel, MLDataset, MLArtifact
+from .type import MLArtifact, MLDataset, MLModel
 
 
 def monitor_exec(print_on_main_worker_only: bool = False) -> Callable:

--- a/tests/components/test_decorators.py
+++ b/tests/components/test_decorators.py
@@ -1,9 +1,9 @@
-from itwinai.components import BaseComponent
-import pytest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
+import pytest
+
+from itwinai.components import BaseComponent, monitor_exec
 from itwinai.distributed import suppress_workers_print
-from itwinai.components import monitor_exec
 
 
 class SilentComponent(BaseComponent):
@@ -126,7 +126,7 @@ def test_monitor_exec_decorator(mock_component):
     with patch('time.time') as mock_time:
         mock_time.side_effect = [100.0, 105.0]  # Simulate 5 seconds execution time
 
-        @ monitor_exec
+        @monitor_exec
         def dummy_method(self):
             return "Execution result"
 

--- a/tests/components/test_decorators.py
+++ b/tests/components/test_decorators.py
@@ -38,10 +38,8 @@ class FakeComponent(BaseComponent):
 @pytest.fixture
 def mock_component():
     """Fixture to provide a mock BaseComponent."""
-    component = MagicMock()
+    component = MagicMock(spec=BaseComponent)
     component.name = "TestComponent"
-    component._printout = MagicMock()
-    component.cleanup = MagicMock()
     return component
 
 
@@ -49,15 +47,17 @@ def mock_component():
 def mock_fake_component():
     """Fixture to provide a FakeComponent instance."""
     component = FakeComponent(max_items=10)
-    component.cleanup = MagicMock()    # Mock the cleanup method
+    component.cleanup = MagicMock(spec=FakeComponent.cleanup)
     return component
 
 
 def test_suppress_workers_print_decorator():
     """Test suppress_workers_print decorator behavior."""
-    with patch('builtins.print') as mock_print, \
-            patch('itwinai.distributed.detect_distributed_environment') as mock_env, \
-            patch('itwinai.distributed.distributed_patch_print') as mock_patch_print:
+    with patch('builtins.print', autospec=True) as mock_print, \
+            patch('itwinai.distributed.detect_distributed_environment',
+                  autospec=True) as mock_env, \
+            patch('itwinai.distributed.distributed_patch_print',
+                  autospec=True) as mock_patch_print:
 
         # Mock environment: global rank different from 0 (non-main worker)
         mock_env.return_value.global_rank = 1
@@ -86,9 +86,11 @@ def test_suppress_workers_print_decorator():
 def test_suppress_workers_print_component():
     """Test suppress_workers_print decorator behavioron SilentComponent's
     execute method."""
-    with patch('builtins.print') as mock_print, \
-            patch('itwinai.distributed.detect_distributed_environment') as mock_env, \
-            patch('itwinai.distributed.distributed_patch_print') as mock_patch_print:
+    with patch('builtins.print', autospec=True) as mock_print, \
+            patch('itwinai.distributed.detect_distributed_environment',
+                  autospec=True) as mock_env, \
+            patch('itwinai.distributed.distributed_patch_print',
+                  autospec=True) as mock_patch_print:
 
         # Initialize the SilentComponent instance
         silent_component = SilentComponent(max_items=10)
@@ -151,10 +153,12 @@ def test_combined_decorators_on_fake_component(mock_fake_component):
     """Test the combination of suppress_workers_print and monitor_exec decorators
     on FakeComponent."""
 
-    with patch('builtins.print') as mock_print, \
-            patch('itwinai.distributed.detect_distributed_environment') as mock_env, \
-            patch('itwinai.distributed.distributed_patch_print') as mock_patch_print, \
-            patch('time.time') as mock_time:
+    with patch('builtins.print', autospec=True) as mock_print, \
+            patch('itwinai.distributed.detect_distributed_environment',
+                  autospec=True) as mock_env, \
+            patch('itwinai.distributed.distributed_patch_print',
+                  autospec=True) as mock_patch_print, \
+            patch('time.time', autospec=True) as mock_time:
 
         # Simulate time progression for execution timing
         mock_time.side_effect = [100.0, 105.0]  # Simulate a 5-second execution time

--- a/tests/components/test_decorators.py
+++ b/tests/components/test_decorators.py
@@ -1,0 +1,199 @@
+from itwinai.components import BaseComponent
+import pytest
+from unittest.mock import patch, MagicMock, call
+
+from itwinai.distributed import suppress_workers_print
+from itwinai.components import monitor_exec
+
+
+class SilentComponent(BaseComponent):
+    """Fake component class to test the decorator meant to suppress print()."""
+
+    def __init__(self, max_items: int, name: str = 'SilentComponent') -> None:
+        super().__init__(name)
+        self.save_parameters(max_items=max_items, name=name)
+        self.max_items = max_items
+
+    @suppress_workers_print
+    def execute(self, foo, bar=123):
+        print("Executing SilentComponent")
+        return "silent component result"
+
+
+class FakeComponent(BaseComponent):
+    """Fake component class to test the use of two decorators at the same time."""
+
+    def __init__(self, max_items: int, name: str = 'FakeComponent') -> None:
+        super().__init__(name)
+        self.save_parameters(max_items=max_items, name=name)
+        self.max_items = max_items
+
+    @suppress_workers_print
+    @monitor_exec
+    def execute(self, foo, bar):
+        print("Executing FakeComponent")
+        return "fake component result"
+
+
+@pytest.fixture
+def mock_component():
+    """Fixture to provide a mock BaseComponent."""
+    component = MagicMock()
+    component.name = "TestComponent"
+    component._printout = MagicMock()
+    component.cleanup = MagicMock()
+    return component
+
+
+@pytest.fixture
+def mock_fake_component():
+    """Fixture to provide a FakeComponent instance."""
+    component = FakeComponent(max_items=10)
+    component.cleanup = MagicMock()    # Mock the cleanup method
+    return component
+
+
+def test_suppress_workers_print_decorator():
+    """Test suppress_workers_print decorator behavior."""
+    with patch('builtins.print') as mock_print, \
+            patch('itwinai.distributed.detect_distributed_environment') as mock_env, \
+            patch('itwinai.distributed.distributed_patch_print') as mock_patch_print:
+
+        # Mock environment: global rank different from 0 (non-main worker)
+        mock_env.return_value.global_rank = 1
+        mock_patch_print.return_value = lambda *args, **kwargs: None  # Suppress print
+
+        @suppress_workers_print
+        def dummy_function():
+            print("This should be suppressed")
+
+        dummy_function()
+        mock_print.assert_not_called()  # Ensure print was suppressed
+
+        # Check that outside the decorated function print can still be used
+        print("This should be printed")
+        mock_print.assert_called_once_with("This should be printed")
+        mock_print.reset_mock()
+
+        # Mock environment: global rank is 0 (main worker)
+        mock_env.return_value.global_rank = 0
+        mock_patch_print.return_value = print  # Use default print
+
+        dummy_function()
+        mock_print.assert_called_once_with("This should be suppressed")
+
+
+def test_suppress_workers_print_component():
+    """Test suppress_workers_print decorator behavioron SilentComponent's
+    execute method."""
+    with patch('builtins.print') as mock_print, \
+            patch('itwinai.distributed.detect_distributed_environment') as mock_env, \
+            patch('itwinai.distributed.distributed_patch_print') as mock_patch_print:
+
+        # Initialize the SilentComponent instance
+        silent_component = SilentComponent(max_items=10)
+
+        # Mock environment: global rank different from 0 (non-main worker)
+        mock_env.return_value.global_rank = 1
+        mock_patch_print.return_value = lambda *args, **kwargs: None  # Suppress print
+
+        # Call the execute method on a non-main worker
+        result = silent_component.execute("foo", bar=123)
+
+        # Ensure the execute method's print statement was suppressed
+        mock_print.assert_not_called()
+        assert result == "silent component result"
+
+        # Check that outside the decorated function print can still be used
+        print("This should be printed")
+        mock_print.assert_called_once_with("This should be printed")
+        mock_print.reset_mock()
+
+        # Mock environment: global rank is 0 (main worker)
+        mock_env.return_value.global_rank = 0
+        mock_patch_print.return_value = print  # Use default print
+
+        # Call the execute method on the main worker
+        result = silent_component.execute("foo", bar=123)
+
+        # Ensure the print statement in the execute method was executed correctly
+        mock_print.assert_called_once_with("Executing SilentComponent")
+        assert result == "silent component result"
+
+
+def test_monitor_exec_decorator(mock_component):
+    """Test monitor_exec decorator behavior."""
+    with patch('time.time') as mock_time:
+        mock_time.side_effect = [100.0, 105.0]  # Simulate 5 seconds execution time
+
+        @ monitor_exec
+        def dummy_method(self):
+            return "Execution result"
+
+        result = dummy_method(mock_component)
+
+        # Assert the result of the decorated function
+        assert result == "Execution result"
+
+        # Check that the start and end messages were logged
+        mock_component._printout.assert_any_call(
+            "Starting execution of 'TestComponent'...")
+        mock_component._printout.assert_any_call("'TestComponent' executed in 5.000s")
+
+        # Ensure the cleanup method was called
+        mock_component.cleanup.assert_called_once()
+
+        # Check that execution time was set correctly
+        assert mock_component.exec_t == 5.0
+
+
+def test_combined_decorators_on_fake_component(mock_fake_component):
+    """Test the combination of suppress_workers_print and monitor_exec decorators
+    on FakeComponent."""
+
+    with patch('builtins.print') as mock_print, \
+            patch('itwinai.distributed.detect_distributed_environment') as mock_env, \
+            patch('itwinai.distributed.distributed_patch_print') as mock_patch_print, \
+            patch('time.time') as mock_time:
+
+        # Simulate time progression for execution timing
+        mock_time.side_effect = [100.0, 105.0]  # Simulate a 5-second execution time
+
+        # Case 1: Non-main worker (print suppressed)
+        mock_env.return_value.global_rank = 1
+        mock_patch_print.return_value = lambda *args, **kwargs: None  # Suppress print
+
+        result = mock_fake_component.execute("foo", "bar")
+        assert result == "fake component result"
+
+        # Ensure the print statement was suppressed for non-main worker
+        mock_print.assert_not_called()
+
+        assert mock_fake_component.exec_t == 5.0
+        mock_fake_component.cleanup.assert_called_once()
+
+        # Reset mock calls for next test case
+        mock_print.reset_mock()
+        mock_fake_component.cleanup.reset_mock()
+        mock_time.side_effect = [100.0, 105.0]  # Simulate a 5-second execution time
+
+        # Case 2: Main worker (print allowed)
+        mock_env.return_value.global_rank = 0
+        mock_patch_print.return_value = print  # Use standard print
+
+        result = mock_fake_component.execute("foo", "bar")
+        assert result == "fake component result"
+
+        # Ensure the print statement was not suppressed for the main worker
+        mock_print.assert_has_calls([
+            call('############################################'),
+            call("# Starting execution of 'FakeComponent'... #"),
+            call('############################################'),
+            call('Executing FakeComponent'),
+            call('######################################'),
+            call("# 'FakeComponent' executed in 5.000s #"),
+            call('######################################')
+        ])
+
+        assert mock_fake_component.exec_t == 5.0
+        mock_fake_component.cleanup.assert_called_once()


### PR DESCRIPTION
Update the `monior_exec` decorator to suppress prints on workers with global rank != 0 only when *explicitly* asked to do so.

Actually, the logic meant to suppress the print on workers  with global rank != 0 has been moved to another decorator, which makes its usage straightforward. Example:

```python
from itwinai.distributed import suppress_workers_print

class SilentComponent(BaseComponent):
    """Fake component class to test the decorator meant to suppress print()."""

    def __init__(self, max_items: int, name: str = 'SilentComponent') -> None:
        super().__init__(name)
        self.save_parameters(max_items=max_items, name=name)
        self.max_items = max_items

    @suppress_workers_print
    def execute(self, foo, bar=123):
        print("Executing SilentComponent")
        return "silent component result"
```

The two decorators also can be used together. Example:

````python
class FakeComponent(BaseComponent):
    """Fake component class to test the use of two decorators at the same time."""

    def __init__(self, max_items: int, name: str = 'FakeComponent') -> None:
        super().__init__(name)
        self.save_parameters(max_items=max_items, name=name)
        self.max_items = max_items

    @suppress_workers_print
    @monitor_exec
    def execute(self, foo, bar):
        print("Executing FakeComponent")
        return "fake component result"

```