### PR TITLE
Update docs for use cases with EURAC

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ contains thoroughly tested features aligned with the toolkit's most recent relea
 
    getting-started/getting_started_with_itwinai
    getting-started/slurm
+   getting-started/plugins
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,6 @@ contains thoroughly tested features aligned with the toolkit's most recent relea
 
    getting-started/getting_started_with_itwinai
    getting-started/slurm
-   getting-started/plugins
 
 .. toctree::
    :maxdepth: 2

--- a/docs/use-cases/3dgan_doc.rst
+++ b/docs/use-cases/3dgan_doc.rst
@@ -1,7 +1,9 @@
 3DGAN
 =====
 
-This section covers the CERN use case that utilizes the `torch-lightning` framework for training and evaluation. Following you can find instructions to execute CERN use case and its integral scripts:
+This section covers the CERN use case that utilizes the `torch-lightning` framework 
+for training and evaluation. Following you can find instructions to execute CERN use 
+case and its integral scripts:
 
 itwinai x 3DGAN
 ---------------
@@ -10,128 +12,16 @@ itwinai x 3DGAN
    :parser: myst_parser.sphinx_
    :start-line: 2
 
-.. toctree::
-   :maxdepth: 5
-
-model.py
-++++++++
-
-.. literalinclude:: ../../use-cases/3dgan/model.py
-   :language: python
-
-
-trainer.py
-++++++++++
-.. literalinclude:: ../../use-cases/3dgan/trainer.py
-   :language: python
-
-
-saver.py
-++++++++
-
-.. literalinclude:: ../../use-cases/3dgan/saver.py
-   :language: python
-
-
-dataloader.py
-+++++++++++++
-
-.. literalinclude:: ../../use-cases/3dgan/dataloader.py
-   :language: python
-
-
-config.yaml
-+++++++++++
-
-This YAML file defines the pipeline configuration for the CERN use case.
-
-.. literalinclude:: ../../use-cases/3dgan/config.yaml
-   :language: yaml
-
-
-create_inference_sample.py
-++++++++++++++++++++++++++
-
-This file defines a pipeline configuration for the CERN use case inference.
-
-.. literalinclude:: ../../use-cases/3dgan/create_inference_sample.py
-   :language: python
-
-
-Dockerfile
-++++++++++
-
-.. literalinclude:: ../../use-cases/3dgan/Dockerfile
-   :language: bash
-
-
-SLURM job script for JSC (HDFML system)
-+++++++++++++++++++++++++++++++++++++++++
-
-.. literalinclude:: ../../use-cases/3dgan/slurm.jsc.sh
-   :language: bash
-
-
-SLURM job script for Vega Supercomputer (GPU partition)
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-.. literalinclude:: ../../use-cases/3dgan/slurm.vega.sh
-   :language: bash
-
 
 interLink x 3DGAN
 -----------------
 
-This section covers the CERN use case integration with `interLink <https://github.com/interTwin-eu/interLink>`_ using ``itwinai``. The following files are integral to this use case:
+The CERN use case also has an integration with the ``interLink`` tool. You can find
+the relevant files in the 
+`interLink folder on Github <https://github.com/interTwin-eu/itwinai/tree/main/use-cases/3dgan/interLink>`_.
+You can also look at the README for more information:
 
 
-.. toctree::
-   :maxdepth: 5
-
-
-3dgan-inference-cpu.yaml
-++++++++++++++++++++++++
-
-.. literalinclude:: ../../use-cases/3dgan/interLink/3dgan-inference-cpu.yaml
-   :language: yaml
-
-
-3dgan-inference.yaml
-++++++++++++++++++++
-
-.. literalinclude:: ../../use-cases/3dgan/interLink/3dgan-inference.yaml
-   :language: yaml
-
-
-3dgan-train.yaml
-++++++++++++++++
-
-.. literalinclude:: ../../use-cases/3dgan/interLink/3dgan-train.yaml
-   :language: yaml
-
-
-
-.. .. automodule:: 3dgan.model
-..     :members:
-..     :undoc-members:
-..     :show-inheritance:
-
-.. .. automodule:: 3dgan.train
-..     :members:
-..     :undoc-members:
-..     :show-inheritance:
-
-.. .. automodule:: 3dgan.trainer
-..     :members:
-..     :undoc-members:
-..     :show-inheritance:
-
-.. .. automodule:: 3dgan.saver
-..     :members:
-..     :undoc-members:
-..     :show-inheritance:
-
-.. .. automodule:: 3dgan.dataloader
-..     :members:
-..     :undoc-members:
-..     :show-inheritance:
+.. include:: ../../use-cases/3dgan/interLink/README.md
+   :parser: myst_parser.sphinx_
+   :start-line: 0

--- a/docs/use-cases/cyclones_doc.rst
+++ b/docs/use-cases/cyclones_doc.rst
@@ -3,47 +3,14 @@ Tropical Cyclones Detection
 
 The code is adapted from the CMCC use case's
 `repository <https://github.com/CMCC-Foundation/ml-tropical-cyclones-detection>`_.
-
-To know more on the interTwin tropical cyclones detection use case and its DT, please visit the published deliverables,
-`D4.1 <https://zenodo.org/records/10417135>`_, 
-`D7.1 <https://zenodo.org/records/10417158>`_ and `D7.3 <https://zenodo.org/records/10224252>`_.
+To know more on the interTwin tropical cyclones detection use case and its DT, please 
+visit the published deliverables, `D4.1 <https://zenodo.org/records/10417135>`_, 
+`D7.1 <https://zenodo.org/records/10417158>`_ and 
+`D7.3 <https://zenodo.org/records/10224252>`_.
+You can find the relevant code in the
+`use case's folder on Github <https://github.com/interTwin-eu/itwinai/tree/main/use-cases/cyclones>`_,
+or by consulting the use case's README: 
 
 .. include:: ../../use-cases/cyclones/README.md
    :parser: myst_parser.sphinx_
    :start-line: 5
-
-pipeline.yaml
-+++++++++++++
-
-This YAML file defines the pipeline configuration for the CMCC use case.
-
-.. literalinclude:: ../../use-cases/cyclones/pipeline.yaml
-   :language: yaml
-
-train.py
-++++++++++
-.. literalinclude:: ../../use-cases/cyclones/train.py
-   :language: python
-
-dataloader.py
-+++++++++++++
-
-.. literalinclude:: ../../use-cases/cyclones/dataloader.py
-   :language: python
-
-trainer.py
-++++++++++
-.. literalinclude:: ../../use-cases/cyclones/trainer.py
-   :language: python
-
-startscript
-+++++++++++
-
-.. literalinclude:: ../../use-cases/cyclones/startscript.sh
-   :language: bash
-
-cyclones_vgg.py
-+++++++++++++++
-
-.. literalinclude:: ../../use-cases/cyclones/cyclones_vgg.py
-   :language: python

--- a/docs/use-cases/eurac_doc.rst
+++ b/docs/use-cases/eurac_doc.rst
@@ -1,19 +1,6 @@
 
 EURAC
 =====
-The EURAC use case ... 
-
-.. The code is adapted from
-.. `this notebook <https://github.com/interTwin-eu/DT-Virgo-notebooks/blob/main/WP_4_4/interTwin_wp_4.4_synthetic_data.ipynb>`_
-.. available on the Virgo use case's `repository <https://github.com/interTwin-eu/DT-Virgo-notebooks>`_.
-..
-.. To know more on the interTwin Virgo Noise detector use case and its DT, please visit the published deliverables,
-.. `D4.2 <https://zenodo.org/records/10417138>`_, 
-.. `D7.2 <https://zenodo.org/records/10417161>`_ and `D7.4 <https://zenodo.org/records/10224277>`_.
-..
-README
-++++++++++++
-
 .. include:: ../../use-cases/eurac/README.md
    :parser: myst_parser.sphinx_
    :start-line: 2

--- a/docs/use-cases/eurac_doc.rst
+++ b/docs/use-cases/eurac_doc.rst
@@ -1,0 +1,55 @@
+
+EURAC
+=====
+The EURAC use case ... 
+
+.. The code is adapted from
+.. `this notebook <https://github.com/interTwin-eu/DT-Virgo-notebooks/blob/main/WP_4_4/interTwin_wp_4.4_synthetic_data.ipynb>`_
+.. available on the Virgo use case's `repository <https://github.com/interTwin-eu/DT-Virgo-notebooks>`_.
+..
+.. To know more on the interTwin Virgo Noise detector use case and its DT, please visit the published deliverables,
+.. `D4.2 <https://zenodo.org/records/10417138>`_, 
+.. `D7.2 <https://zenodo.org/records/10417161>`_ and `D7.4 <https://zenodo.org/records/10224277>`_.
+..
+README
+++++++++++++
+
+.. include:: ../../use-cases/eurac/README.md
+   :parser: myst_parser.sphinx_
+   :start-line: 2
+
+..
+..
+.. config.yaml
+.. +++++++++++
+.. .. literalinclude:: ../../use-cases/virgo/config.yaml
+..    :language: yaml
+..
+..
+.. data.py
+.. +++++++
+..
+.. .. literalinclude:: ../../use-cases/virgo/data.py
+..    :language: python
+..
+..
+.. runall.sh
+.. +++++++++
+..
+.. .. literalinclude:: ../../use-cases/virgo/runall.sh
+..    :language: bash
+..
+..
+.. slurm.sh
+.. ++++++++
+..
+.. .. literalinclude:: ../../use-cases/virgo/slurm.sh
+..    :language: bash
+..
+..
+.. trainer.py
+.. ++++++++++
+.. .. literalinclude:: ../../use-cases/virgo/trainer.py
+..    :language: python
+..
+..

--- a/docs/use-cases/eurac_doc.rst
+++ b/docs/use-cases/eurac_doc.rst
@@ -1,42 +1,11 @@
 
 EURAC
 =====
+You can find the relevant code for the EURAC use case in the 
+`use case's folder on Github <https://github.com/interTwin-eu/itwinai/tree/main/use-cases/eurac>`_,
+or by consulting the use case's README: 
+
+
 .. include:: ../../use-cases/eurac/README.md
    :parser: myst_parser.sphinx_
    :start-line: 2
-
-..
-..
-.. config.yaml
-.. +++++++++++
-.. .. literalinclude:: ../../use-cases/virgo/config.yaml
-..    :language: yaml
-..
-..
-.. data.py
-.. +++++++
-..
-.. .. literalinclude:: ../../use-cases/virgo/data.py
-..    :language: python
-..
-..
-.. runall.sh
-.. +++++++++
-..
-.. .. literalinclude:: ../../use-cases/virgo/runall.sh
-..    :language: bash
-..
-..
-.. slurm.sh
-.. ++++++++
-..
-.. .. literalinclude:: ../../use-cases/virgo/slurm.sh
-..    :language: bash
-..
-..
-.. trainer.py
-.. ++++++++++
-.. .. literalinclude:: ../../use-cases/virgo/trainer.py
-..    :language: python
-..
-..

--- a/docs/use-cases/mnist_doc.rst
+++ b/docs/use-cases/mnist_doc.rst
@@ -1,7 +1,12 @@
 MNIST
 =====
 
-This section covers the MNIST use case, which utilizes the `torch-lightning` framework for training and evaluation. The following files are integral to this use case:
+This section covers the MNIST use case. This use case has been implemented using three
+different strategies, ``TensorFlow``, ``PyTorch`` and ``PyTorch Lightning``. You can 
+find the files relevant to this use case
+in the `use case's folder on Github <https://github.com/interTwin-eu/itwinai/tree/main/use-cases/mnist>`_.
+
+For more information on each implementation, consult their respective READMEs:
 
 Torch Lightning
 ---------------
@@ -11,169 +16,9 @@ Torch Lightning
    :start-line: 2
 
 
-.. toctree::
-   :maxdepth: 5
-
-dataloader.py
-+++++++++++++
-
-The `dataloader.py` script is responsible for loading the MNIST dataset and preparing it for training.
-
-.. literalinclude:: ../../use-cases/mnist/torch-lightning/dataloader.py
-   :language: python
-
-.. .. automodule:: torch-lightning.dataloader
-..    :members:
-..    :undoc-members:
-..    :show-inheritance:
-
-config.yaml
-+++++++++++
-
-This YAML file defines the pipeline configuration for the MNIST use case. It includes settings for the model, training, and evaluation.
-
-.. literalinclude:: ../../use-cases/mnist/torch-lightning/config.yaml
-   :language: yaml
-
-startscript
-+++++++++++
-
-The `startscript` is a shell script to initiate the training process. It sets up the environment and starts the training using the `train.py` script.
-
-.. literalinclude:: ../../use-cases/mnist/torch-lightning/startscript
-   :language: bash
-
-
-utils.py
-++++++++
-
-The `utils.py` script includes utility functions and classes that are used across the MNIST use case.
-
-.. literalinclude:: ../../use-cases/mnist/torch-lightning/utils.py
-   :language: python
-
-
-
-This section covers the MNIST use case, which utilizes the `torch` framework for training and evaluation. The following files are integral to this use case:
-
 PyTorch
 -------
 
 .. include:: ../../use-cases/mnist/torch/README.md
    :parser: myst_parser.sphinx_
    :start-line: 2
-
-
-
-.. toctree::
-   :maxdepth: 5
-
-dataloader.py
-+++++++++++++
-
-The `dataloader.py` script is responsible for loading the MNIST dataset and preparing it for training.
-
-.. literalinclude:: ../../use-cases/mnist/torch/dataloader.py
-   :language: python
-
-
-Dockerfile
-++++++++++
-
-.. literalinclude:: ../../use-cases/mnist/torch/Dockerfile
-   :language: bash
-
-
-create_inference_sample.py
-++++++++++++++++++++++++++
-
-This file defines a pipeline configuration for the MNIST use case inference.
-
-.. literalinclude:: ../../use-cases/mnist/torch/create_inference_sample.py
-   :language: python
-
-model.py
-++++++++
-
-The `model.py` script is responsible for loading a simple model.
-
-.. literalinclude:: ../../use-cases/mnist/torch/model.py
-   :language: python
-
-config.yaml
-+++++++++++
-
-This YAML file defines the pipeline configuration for the MNIST use case. It includes settings for the model, training, and evaluation.
-
-.. literalinclude:: ../../use-cases/mnist/torch/config.yaml
-   :language: yaml
-
-startscript.sh
-++++++++++++++
-
-The `startscript` is a shell script to initiate the training process. It sets up the environment and starts the training using the `train.py` script.
-
-.. literalinclude:: ../../use-cases/mnist/torch/startscript.sh
-   :language: bash
-
-
-saver.py
-++++++++
-...
-
-.. literalinclude:: ../../use-cases/mnist/torch/saver.py
-   :language: python
-
-
-runall.sh
-+++++++++
-
-.. literalinclude:: ../../use-cases/mnist/torch/runall.sh
-   :language: bash
-
-
-slurm.sh
-++++++++
-
-.. literalinclude:: ../../use-cases/mnist/torch/slurm.sh
-   :language: bash
-
-
-
-This section covers the MNIST use case, which utilizes the `tensorflow` framework for training and evaluation. The following files are integral to this use case:
-
-Tensorflow
-----------
-
-.. toctree::
-   :maxdepth: 5
-
-dataloader.py
-+++++++++++++
-
-The `dataloader.py` script is responsible for loading the MNIST dataset and preparing it for training.
-
-.. literalinclude:: ../../use-cases/mnist/tensorflow/dataloader.py
-   :language: python
-
-
-pipeline.yaml
-+++++++++++++
-
-This YAML file defines the pipeline configuration for the MNIST use case. It includes settings for the model, training, and evaluation.
-
-.. literalinclude:: ../../use-cases/mnist/tensorflow/pipeline.yaml
-   :language: yaml
-
-
-startscript.sh
-++++++++++++++
-
-The `startscript` is a shell script to initiate the training pipeline.
-
-.. literalinclude:: ../../use-cases/mnist/tensorflow/startscript.sh
-   :language: bash
-
-
-
-   

--- a/docs/use-cases/use_cases.rst
+++ b/docs/use-cases/use_cases.rst
@@ -1,42 +1,33 @@
 How to run a use case
 ======================
 
-First, create the use case's Python environment (i.e., PyTorch or TensorFlow)
-as described `here <https://itwinai.readthedocs.io/latest/getting_started_with_itwinai.html#environment-setup>`_, and activate it.
-Then, install use case-specific dependencies, if any:
+Each use case comes with their own tutorial on how to run it. Before running them,
+however, you should set up a Python virtual environment. Refer to the
+:doc:`getting started section <../getting-started/getting_started_with_itwinai.rst`
+for more information on how to do this.
+
+After installing and activating the virtual environment, you will want to install the
+use-case specific dependencies, if applicable. This can be done by first ``cd``-ing
+into the use-case directory and then installing the requirements, as follows
 
 .. code-block:: bash
 
-   pip install -r /use/case/path/requirements.txt
+   cd use-cases/<name-of-use-case>
+   pip install -r requirements.txt
 
 
-Alternatively, you can use the use case Docker image, if available.
-
-Then, go to the use case's directory:
-
-.. code-block:: bash
-
-   cd /use/case/path
+Alternatively, you can use the use-case Docker image, if available. After setting
+everything up, you can now run the use case as specified in the use case's tutorial.
 
 
-From here you can run the use case (having activated the correct Python env):
-
-.. code-block:: bash
-
-   # Locally
-   python train.py [OPTIONS...]
-
-   # With SLURM: stdout and stderr will be saved to job.out and job.err files
-   sbatch startscript
-
-
-
-Fast particle detector simulation | CERN use case
+Fast particle detector simulation | CERN 
 =================================================
 
-The first ``interTwin`` use case integrated with ``itwinai`` framework is the DT for fast particle detector simulation. 
-3D Generative Adversarial Network (3DGAN) for generation of images of calorimeter depositions. 
-This project is based on the prototype `3DGAN <https://github.com/svalleco/3Dgan/tree/Anglegan/keras>`_ model developed at CERN and is implemented on PyTorch Lightning framework.
+The first ``interTwin`` use case integrated with ``itwinai`` framework is the DT for
+fast particle detector simulation. 3D Generative Adversarial Network (3DGAN) for
+generation of images of calorimeter depositions. This project is based on the
+prototype `3DGAN <https://github.com/svalleco/3Dgan/tree/Anglegan/keras>`_ model
+developed at CERN and is implemented on PyTorch Lightning framework.
 
 .. toctree::
    :maxdepth: 2
@@ -44,11 +35,11 @@ This project is based on the prototype `3DGAN <https://github.com/svalleco/3Dgan
    3dgan_doc
 
 
-MNIST dataset use case
+MNIST dataset 
 =========================
 
-MNIST image classification is used to provide an example on 
-how to define an end-to-end digital twin workflow with the ``itwinai`` software.
+MNIST image classification is used to provide an example on how to define an end-to-end
+digital twin workflow with the ``itwinai`` software.
 
 .. toctree::
    :maxdepth: 2
@@ -56,37 +47,23 @@ how to define an end-to-end digital twin workflow with the ``itwinai`` software.
    mnist_doc
 
 
-Tropical Cyclones Detection | CMCC use case
+Tropical Cyclones Detection | CMCC 
 ==============================================
 
-Below you can find the training and validation of a Tropical Cyclones (TCs) Detection model, developed by CMCC, integrated with ``itwinai`` framework.
-
-.. toctree::
-   :maxdepth: 1
-
-   cyclones_doc
+You can find more information on the ``itwinai`` integration of the Tropical Cyclones
+(TCs) Detection model, developed by CMCC, in the
+:doc:`Tropical Cyclones Detection documentation <cyclones_doc>`.
 
 
-
-Noise Simulation for Gravitational Waves Detector (Virgo) | INFN use case
+Noise Simulation for Gravitational Waves Detector (Virgo) | INFN 
 ===========================================================================
 
-Below you can find the integration of the Virgo use case with ``itwinai`` framework, developed by INFN.
-
-.. toctree::
-   :maxdepth: 1
-
-   virgo_doc
+You can find more information on the Virgo use-case integration with the ``itwinai``
+framework in the :doc:`Virgo documentation <virgo_doc>`.
 
 
-Drought Early Warning in the Alps | EURAC use case
-===========================================================================
+Drought Early Warning in the Alps | EURAC 
+===========================================
 
-Below you can find the integration of the EURAC use case with the ``itwinai`` 
-framework. 
-
-.. toctree::
-   :maxdepth: 1
-
-   virgo_doc
-
+You can find more information on the EURAC use-case integration with the ``itwinai``
+in the :doc:`EURAC documentation <eurac_doc>`.

--- a/docs/use-cases/use_cases.rst
+++ b/docs/use-cases/use_cases.rst
@@ -78,3 +78,15 @@ Below you can find the integration of the Virgo use case with ``itwinai`` framew
 
    virgo_doc
 
+
+Drought Early Warning in the Alps | EURAC use case
+===========================================================================
+
+Below you can find the integration of the EURAC use case with the ``itwinai`` 
+framework. 
+
+.. toctree::
+   :maxdepth: 1
+
+   virgo_doc
+

--- a/docs/use-cases/virgo_doc.rst
+++ b/docs/use-cases/virgo_doc.rst
@@ -9,44 +9,12 @@ To know more on the interTwin Virgo Noise detector use case and its DT, please v
 `D4.2 <https://zenodo.org/records/10417138>`_, 
 `D7.2 <https://zenodo.org/records/10417161>`_ and `D7.4 <https://zenodo.org/records/10224277>`_.
 
-Installation
-++++++++++++
+You can find the relevant code in the
+`use case's folder on Github <https://github.com/interTwin-eu/itwinai/tree/main/use-cases/virgo>`_,
+or by consulting the use case's README: 
+
 
 .. include:: ../../use-cases/virgo/README.md
    :parser: myst_parser.sphinx_
    :start-line: 6
-
-
-config.yaml
-+++++++++++
-.. literalinclude:: ../../use-cases/virgo/config.yaml
-   :language: yaml
-
-
-data.py
-+++++++
-
-.. literalinclude:: ../../use-cases/virgo/data.py
-   :language: python
-
-
-runall.sh
-+++++++++
-
-.. literalinclude:: ../../use-cases/virgo/runall.sh
-   :language: bash
-
-
-slurm.sh
-++++++++
-
-.. literalinclude:: ../../use-cases/virgo/slurm.sh
-   :language: bash
-
-
-trainer.py
-++++++++++
-.. literalinclude:: ../../use-cases/virgo/trainer.py
-   :language: python
-
 


### PR DESCRIPTION
# Summary
Add EURAC to the list of use cases found in the docs and change the use-cases page slightly for a (IMO) cleaner look.

# Noteworthy
I chose to not add more than the readme for EURAC as I found that adding the code files is messy and doesn't add anything. Personally, I feel that if someone wants to explore the code, they can either do it on GitHub or (even better) in their own text editor. 
