### PR TITLE
Wandb offline mode

### DIFF
--- a/src/itwinai/loggers.py
+++ b/src/itwinai/loggers.py
@@ -667,6 +667,9 @@ class WandBLogger(Logger):
             workers; if int log on worker with rank equal to log_on_workers;
             if List[int], log on workers which rank is in the list.
             Defaults to 0 (the global rank of the main worker).
+        offline_mode (str, optional): Use this option if working on compute
+            node without internet access. Saves logs locally. 
+            Defaults to 'False'.
     """
 
     # TODO: add support for artifacts logging
@@ -689,10 +692,12 @@ class WandBLogger(Logger):
         project_name: str = BASE_EXP_NAME,
         log_freq: Union[int, Literal["epoch", "batch"]] = "epoch",
         log_on_workers: Union[int, List[int]] = 0,
+        offline_mode: bool = False,
     ) -> None:
         savedir = os.path.join(savedir, "wandb")
         super().__init__(savedir=savedir, log_freq=log_freq, log_on_workers=log_on_workers)
         self.project_name = project_name
+        self.offline_mode = offline_mode
 
     def create_logger_context(self, rank: Optional[int] = None) -> None:
         """
@@ -709,7 +714,8 @@ class WandBLogger(Logger):
 
         os.makedirs(os.path.join(self.savedir, "wandb"), exist_ok=True)
         self.active_run = wandb.init(
-            dir=os.path.abspath(self.savedir), project=self.project_name
+            dir=os.path.abspath(self.savedir), project=self.project_name,
+            mode="offline" if self.offline_mode else "online",
         )
 
     def destroy_logger_context(self):

--- a/src/itwinai/loggers.py
+++ b/src/itwinai/loggers.py
@@ -668,7 +668,7 @@ class WandBLogger(Logger):
             if List[int], log on workers which rank is in the list.
             Defaults to 0 (the global rank of the main worker).
         offline_mode (str, optional): Use this option if working on compute
-            node without internet access. Saves logs locally. 
+            node without internet access. Saves logs locally.
             Defaults to 'False'.
     """
 


### PR DESCRIPTION
Added offline mode as initialisation parameter to allow using the wandb logger locally when there is no internet access, e.g. on compute nodes

**Related issue :** #168
