### PR TITLE
Fix logger initialization

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,6 +55,9 @@ jobs:
           VALIDATE_JSON_PRETTIER: false
           VALIDATE_CSS_PRETTIER: false
           VALIDATE_KUBERNETES_KUBECONFORM: false
+          # Both options below should be already covered by ruff
+          VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_FLAKE8: false
 
           # Only check new or edited files
           VALIDATE_ALL_CODEBASE: false

--- a/src/itwinai/loggers.py
+++ b/src/itwinai/loggers.py
@@ -368,6 +368,7 @@ class ConsoleLogger(Logger):
         self.worker_rank = rank
 
         if not self.should_log():
+            self.is_initialized = True
             return
 
         logging.info(f"Initializing {self.__class__.__name__} on rank {rank}")
@@ -526,6 +527,8 @@ class MLFlowLogger(Logger):
         self.run_name = run_name
         self.experiment_name = experiment_name
 
+        mfl_savedir.mkdir(parents=True, exist_ok=True)
+
         self.tracking_uri = (
             self.tracking_uri
             or os.environ.get("MLFLOW_TRACKING_URI")
@@ -549,6 +552,7 @@ class MLFlowLogger(Logger):
         self.worker_rank = rank
 
         if not self.should_log():
+            self.is_initialized = True
             return
 
         logging.info(f"Initializing {self.__class__.__name__} on rank {rank}")
@@ -734,6 +738,7 @@ class WandBLogger(Logger):
         self.worker_rank = rank
 
         if not self.should_log():
+            self.is_initialized = True
             return
 
         logging.info(f"Initializing {self.__class__.__name__} on rank {rank}")
@@ -864,6 +869,7 @@ class TensorBoardLogger(Logger):
         self.worker_rank = rank
 
         if not self.should_log():
+            self.is_initialized = True
             return
 
         logging.info(f"Initializing {self.__class__.__name__} on rank {rank}")
@@ -1121,6 +1127,7 @@ class Prov4MLLogger(Logger):
         self.worker_rank = rank
 
         if not self.should_log():
+            self.is_initialized = True
             return
 
         logging.info(f"Initializing {self.__class__.__name__} on rank {rank}")

--- a/src/itwinai/torch/loggers.py
+++ b/src/itwinai/torch/loggers.py
@@ -57,8 +57,6 @@ class ItwinaiLogger(LightningLogger):
         self._logged_model_time = {}
         self._checkpoint_callback = None
 
-        self._initialized = False
-
     @property
     def name(self) -> Optional[str]:
         """Return the experiment name."""
@@ -85,10 +83,9 @@ class ItwinaiLogger(LightningLogger):
         Returns:
             Logger: The itwinai logger instance.
         """
-        if not self._initialized:
+        if not self.itwinai_logger.is_initialized:
             # With the rank_zero_experiment decorators the rank will always be 0
             self.itwinai_logger.create_logger_context(rank=0)
-            self._initialized = True
 
         return self.itwinai_logger
 
@@ -104,7 +101,7 @@ class ItwinaiLogger(LightningLogger):
                 (LightningLogger)
             finalize functions signature, and therefore must be propagated here.
         """
-        if not self._initialized:
+        if not self.itwinai_logger.is_initialized:
             return
 
         # Log checkpoints if the last checkpoint was saved but not logged

--- a/tests/loggers/conftest.py
+++ b/tests/loggers/conftest.py
@@ -26,14 +26,14 @@ from itwinai.loggers import (
 from itwinai.torch.loggers import ItwinaiLogger as PyTorchLightningLogger
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def console_logger():
     with tempfile.TemporaryDirectory() as temp_dir:
         save_dir = Path(temp_dir) / "console/test_mllogs"
         yield ConsoleLogger(savedir=save_dir, log_freq=1)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def mlflow_logger():
     with tempfile.TemporaryDirectory() as temp_dir:
         save_dir = Path(temp_dir) / "mlflow/test_mllogs"
@@ -43,33 +43,33 @@ def mlflow_logger():
         )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def wandb_logger():
     with tempfile.TemporaryDirectory() as temp_dir:
         save_dir = Path(temp_dir) / "wandb/test_mllogs"
-        yield WandBLogger(savedir=save_dir, project_name="test_project")
+        yield WandBLogger(savedir=save_dir, project_name="test_project", offline_mode=True)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def tensorboard_logger_tf():
     with tempfile.TemporaryDirectory() as temp_dir:
         save_dir = Path(temp_dir) / "tf_tb/test_mllogs"
         yield TensorBoardLogger(savedir=save_dir, framework="tensorflow")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def tensorboard_logger_torch():
     with tempfile.TemporaryDirectory() as temp_dir:
         save_dir = Path(temp_dir) / "torch_tb/test_mllogs"
         yield TensorBoardLogger(savedir=save_dir, framework="pytorch")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def prov4ml_logger():
     return Prov4MLLogger()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def loggers_collection(
     console_logger,
     mlflow_logger,

--- a/tests/loggers/conftest.py
+++ b/tests/loggers/conftest.py
@@ -33,7 +33,7 @@ def console_logger():
         yield ConsoleLogger(savedir=save_dir, log_freq=1)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def mlflow_logger():
     with tempfile.TemporaryDirectory() as temp_dir:
         save_dir = Path(temp_dir) / "mlflow/test_mllogs"
@@ -92,6 +92,9 @@ def loggers_collection(
 def lightning_mock_loggers():
     """Setup a generic PyTorchLightningLogger with mock loggers for testing."""
     itwinai_logger_mock = MagicMock(spec=Logger)
+    # Setting default attributes as per class definition
+    itwinai_logger_mock.is_initialized = False
+    itwinai_logger_mock.worker_rank = 0
     lightning_logger = PyTorchLightningLogger(itwinai_logger=itwinai_logger_mock)
 
     return itwinai_logger_mock, lightning_logger

--- a/tests/loggers/test_prov4ml.py
+++ b/tests/loggers/test_prov4ml.py
@@ -68,6 +68,7 @@ def test_create_logger_context_should_not_log(logger_instance):
 
 def test_save_hyperparameters(logger_instance):
     logger_instance.should_log = MagicMock(return_value=True)
+    logger_instance.create_logger_context(rank=1)
     params = {"learning_rate": 0.01, "batch_size": 32}
     with patch("prov4ml.log_param") as log_param:
         logger_instance.save_hyperparameters(params)
@@ -77,6 +78,7 @@ def test_save_hyperparameters(logger_instance):
 
 def test_log_metric(logger_instance):
     logger_instance.should_log = MagicMock(return_value=True)
+    logger_instance.create_logger_context(rank=1)
 
     with patch("prov4ml.log_metric") as log_metric:
         logger_instance.log(item=0.95, identifier="accuracy", kind="metric", step=1)
@@ -88,6 +90,7 @@ def test_log_metric(logger_instance):
 
 def test_log_flops_per_batch(logger_instance):
     logger_instance.should_log = MagicMock(return_value=True)
+    logger_instance.create_logger_context(rank=1)
 
     model_mock, batch_mock = MagicMock(), MagicMock()
     with patch("prov4ml.log_flops_per_batch") as log_flops_pb:
@@ -106,6 +109,7 @@ def test_log_flops_per_batch(logger_instance):
 
 def test_log_flops_per_epoch(logger_instance):
     logger_instance.should_log = MagicMock(return_value=True)
+    logger_instance.create_logger_context(rank=1)
 
     model_mock, dataset_mock = MagicMock(), MagicMock()
     with patch("prov4ml.log_flops_per_epoch") as log_flops_pe:
@@ -124,6 +128,7 @@ def test_log_flops_per_epoch(logger_instance):
 
 def test_log_system(logger_instance):
     logger_instance.should_log = MagicMock(return_value=True)
+    logger_instance.create_logger_context(rank=1)
 
     with patch("prov4ml.log_system_metrics") as log_system:
         logger_instance.log(item=None, identifier=None, kind="system", step=1)
@@ -133,6 +138,7 @@ def test_log_system(logger_instance):
 
 def test_log_carbon(logger_instance):
     logger_instance.should_log = MagicMock(return_value=True)
+    logger_instance.create_logger_context(rank=1)
 
     with patch("prov4ml.log_carbon_metrics") as log_carbon:
         logger_instance.log(item=None, identifier=None, kind="carbon", step=1)
@@ -142,6 +148,7 @@ def test_log_carbon(logger_instance):
 
 def test_log_execution_time(logger_instance):
     logger_instance.should_log = MagicMock(return_value=True)
+    logger_instance.create_logger_context(rank=1)
 
     with patch("prov4ml.log_current_execution_time") as log_exec_time:
         logger_instance.log(
@@ -155,6 +162,7 @@ def test_log_execution_time(logger_instance):
 
 def test_log_model(logger_instance):
     logger_instance.should_log = MagicMock(return_value=True)
+    logger_instance.create_logger_context(rank=1)
 
     model_mock = MagicMock()
     with patch("prov4ml.save_model_version") as log_model:
@@ -167,6 +175,7 @@ def test_log_model(logger_instance):
 
 def test_log_best_model(logger_instance):
     logger_instance.should_log = MagicMock(return_value=True)
+    logger_instance.create_logger_context(rank=1)
 
     model_mock = MagicMock()
     with patch("prov4ml.log_model") as log_best_model:
@@ -184,6 +193,7 @@ def test_log_best_model(logger_instance):
 
 def test_log_prov_documents(logger_instance, mlflow_run):
     logger_instance.should_log = MagicMock(return_value=True)
+    logger_instance.create_logger_context(rank=1)
 
     with patch("prov4ml.log_provenance_documents") as log_prov_documents:
         log_prov_documents.return_value = ["doc1", "doc2"]


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

- improve the mechanism used to ensure that a logger is used after having been properly initialized
- make the logger wrapper/adapter for Lightning more robust by avoiding the corner case in which a logger is initialized twice
- add tests on initialization

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :** #283 
