### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ See the latest version of our docs [here](https://itwinai.readthedocs.io/).
 ## Installation
 
 For instructions on how to install `itwinai`, please refer to the
-[user installation guide](https://itwinai.readthedocs.io/installation/user_installation.html)
+[user installation guide](https://itwinai.readthedocs.io/latest/installation/user_installation.html)
 or the
-[developer installation guide](https://itwinai.readthedocs.io/installation/developer_installation.html),
+[developer installation guide](https://itwinai.readthedocs.io/latest/installation/developer_installation.html),
 depending on whether you are a user or developer
 
 For information about how to use containers or how to test with pytest, you can look


### PR DESCRIPTION
Currently the links in the README are missing the "latest/" part of the URL, so they don't work. This PR adds that part so that they work again. 