### PR TITLE
Small fix to make virgo work again

### DIFF
--- a/src/itwinai/torch/trainer.py
+++ b/src/itwinai/torch/trainer.py
@@ -1288,16 +1288,16 @@ class RayTorchTrainer(Trainer):
         random_seed: int = 1234,
     ) -> None:
         super().__init__(name=name)
-        self.logger = logger
-        self._set_strategy_and_init_ray(strategy)
-        self._set_configs(config=config)
-        self.torch_rng = set_seed(random_seed)
-
         import ray.train
         import ray.tune
 
         self.ray_train = ray.train
         self.ray_tune = ray.tune
+
+        self.logger = logger
+        self._set_strategy_and_init_ray(strategy)
+        self._set_configs(config=config)
+        self.torch_rng = set_seed(random_seed)
 
     def _set_strategy_and_init_ray(self, strategy: str) -> None:
         """Set the distributed training strategy. This will initialize the ray backend.


### PR DESCRIPTION
# Summary

Okay, this PR changes like three lines, but this needed to be fixed for Virgo to run with HPO - the other issue with the constant losses is fixed if I use only 24 CPUs per node. I had thought that juwels has 48 per node (and I think it does?), but if I used even 44, the duplicate losses would happen. Weird, but 💁🏼‍♀️

