### PR TITLE
Functionality for aggregating different runs in the scalability report

### DIFF
--- a/src/itwinai/cli.py
+++ b/src/itwinai/cli.py
@@ -96,22 +96,19 @@ def generate_scalability_report(
     if run_ids:
         base_directories_for_runs = [log_dir_path / run_id for run_id in run_ids.split(",")]
         # Ensure that all passed run_ids actually exist as directories
-        non_existent_path: Path | None = next(
-            (path for path in base_directories_for_runs if not path.exists()), None
-        )
-        if non_existent_path:
-            raise ValueError(
-                f"Given run_id path does not exist: '{non_existent_path.resolve()}'!"
-            )
+        non_existent_paths = [
+            str(path.resolve()) for path in base_directories_for_runs if not path.exists()
+        ]
+        if non_existent_paths:
+            raise ValueError(f"Given run_id paths do not exist: '{non_existent_paths}'!")
     else:
         # Ensure that all elements in log_dir are directories
-        non_directory_path: Path | None = next(
-            (path for path in log_dir_path.iterdir() if not path.is_dir()), None
-        )
-        if non_directory_path:
+        non_directory_paths = [
+            str(path.resolve()) for path in log_dir_path.iterdir() if not path.is_dir()
+        ]
+        if non_directory_paths:
             raise ValueError(
-                "Found element in log_dir that was not a directory: "
-                f"'{non_directory_path.resolve()}'"
+                f"Found elements in log_dir that are not directories: '{non_directory_paths}'"
             )
         base_directories_for_runs = list(log_dir_path.iterdir())
 

--- a/src/itwinai/cli.py
+++ b/src/itwinai/cli.py
@@ -109,11 +109,19 @@ def generate_scalability_report(
                     f"Found element in logdir that was not itself a directory: "
                     f"{path_elem.resolve()}"
                 )
-            epoch_time_logdirs.append(path_elem / "epoch-time")
-            gpu_data_logdirs.append(path_elem / "gpu-energy-data")
-            comm_time_logdirs.append(path_elem / "communication-data")
+
+            # Creating all potential paths and adding them if they exist
+            epoch_time_logdir = path_elem / "epoch-time"
+            gpu_data_logdir = path_elem / "gpu-energy-data"
+            comm_time_logdir = path_elem / "communication-data"
+
+            if epoch_time_logdir.exists():
+                epoch_time_logdirs.append(epoch_time_logdir)
+            if gpu_data_logdir.exists():
+                gpu_data_logdirs.append(gpu_data_logdir)
+            if comm_time_logdir.exists():
+                comm_time_logdirs.append(comm_time_logdir)
     else:
-        # Make sure run_id actually exists
         for run_id in run_id_list:
             run_path = log_dir_path / run_id
             if not run_path.exists():
@@ -121,9 +129,18 @@ def generate_scalability_report(
                     f"No directory with given run_id: '{run_id}' exists! Path should have been "
                     f"'{run_path.resolve()}', but was not found!"
                 )
-            epoch_time_logdirs.append(log_dir_path / run_id / "epoch-time")
-            gpu_data_logdirs.append(log_dir_path / run_id / "gpu-energy-data")
-            comm_time_logdirs.append(log_dir_path / run_id / "communication-data")
+
+            # Creating all potential paths and adding them if they exist
+            epoch_time_logdir = log_dir_path / run_id / "epoch-time"
+            gpu_data_logdir = log_dir_path / run_id / "gpu-energy-data"
+            comm_time_logdir = log_dir_path / run_id / "communication-data"
+
+            if epoch_time_logdir.exists():
+                epoch_time_logdirs.append(epoch_time_logdir)
+            if gpu_data_logdir.exists():
+                gpu_data_logdirs.append(gpu_data_logdir)
+            if comm_time_logdir.exists():
+                comm_time_logdirs.append(comm_time_logdir)
 
     # Setting the backup directory from run name
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/src/itwinai/cli.py
+++ b/src/itwinai/cli.py
@@ -54,7 +54,9 @@ def generate_scalability_report(
     run_ids: Annotated[
         str | None,
         typer.Option(
-            help="Which run ids to read, presented as comma-separated values, e.g. 'run0,run1'."
+            help=(
+                "Which run ids to read, presented as comma-separated values, e.g. 'run0,run1'."
+            )
         ),
     ] = None,
     backup_root_dir: Annotated[

--- a/src/itwinai/cli.py
+++ b/src/itwinai/cli.py
@@ -53,7 +53,9 @@ def generate_scalability_report(
     ] = False,
     run_ids: Annotated[
         str | None,
-        typer.Option(help="Which run ids to read, presented as comma-separated values."),
+        typer.Option(
+        help="Which run ids to read, presented as comma-separated values, e.g. 'run0,run1'."
+    ),
     ] = None,
     backup_root_dir: Annotated[
         str, typer.Option(help=("Which directory to store the backup files in."))

--- a/src/itwinai/cli.py
+++ b/src/itwinai/cli.py
@@ -54,8 +54,8 @@ def generate_scalability_report(
     run_ids: Annotated[
         str | None,
         typer.Option(
-        help="Which run ids to read, presented as comma-separated values, e.g. 'run0,run1'."
-    ),
+            help="Which run ids to read, presented as comma-separated values, e.g. 'run0,run1'."
+        ),
     ] = None,
     backup_root_dir: Annotated[
         str, typer.Option(help=("Which directory to store the backup files in."))
@@ -126,8 +126,8 @@ def generate_scalability_report(
             run_path = log_dir_path / run_id
             if not run_path.exists():
                 raise ValueError(
-                    f"No directory with given run_id: '{run_id}' exists! Path should have been "
-                    f"'{run_path.resolve()}', but was not found!"
+                    f"No directory with given run_id: '{run_id}' exists! Path should have been"
+                    f" '{run_path.resolve()}', but was not found!"
                 )
 
             # Creating all potential paths and adding them if they exist
@@ -144,7 +144,10 @@ def generate_scalability_report(
 
     # Setting the backup directory from run name
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    backup_run_id = "_".join(run_id_list) + f"_{timestamp}" if run_id_list else f"aggregated_run_{timestamp}"
+    if run_id_list:
+        backup_run_id = "_".join(run_id_list) + f"_{timestamp}"
+    else:
+        backup_run_id = f"aggregated_run_{timestamp}"
     backup_dir = Path(backup_root_dir) / backup_run_id
 
     epoch_time_backup_dir = backup_dir / "epoch-time"
@@ -176,24 +179,23 @@ def generate_scalability_report(
         plot_file_suffix=plot_file_suffix,
     )
 
-
     print()
     if epoch_time_table is not None:
         print("#" * 8, "Epoch Time Report", "#" * 8)
         print(epoch_time_table, "\n")
-    else: 
+    else:
         print("No Epoch Time Data Found\n")
 
     if gpu_data_table is not None:
         print("#" * 8, "GPU Data Report", "#" * 8)
         print(gpu_data_table, "\n")
-    else: 
+    else:
         print("No GPU Data Found\n")
 
     if communication_data_table is not None:
         print("#" * 8, "Communication Data Report", "#" * 8)
         print(communication_data_table, "\n")
-    else: 
+    else:
         print("No Communication Data Found\n")
 
 

--- a/src/itwinai/cli.py
+++ b/src/itwinai/cli.py
@@ -122,12 +122,10 @@ def generate_scalability_report(
         epoch_time_logdirs.append(log_dir_path / run_id / "epoch-time")
         gpu_data_logdirs.append(log_dir_path / run_id / "gpu-energy-data")
         comm_time_logdirs.append(log_dir_path / run_id / "communication-data")
-    print()
 
-    # TODO: Add run_id into this, somehow
-    # Setting the backup directory from exp name and run name
-    run_id = run_id or f"run_{uuid.uuid4().hex[:6]}"
-    backup_dir = Path(backup_root_dir) / run_id
+    # Setting the backup directory from run name
+    backup_run_id = run_id or f"aggregated_run_{uuid.uuid4().hex[:6]}"
+    backup_dir = Path(backup_root_dir) / backup_run_id
     epoch_time_backup_dir = backup_dir / "epoch-time"
     gpu_data_backup_dir = backup_dir / "gpu-energy-data"
     communication_data_backup_dir = backup_dir / "communication-data"
@@ -154,16 +152,25 @@ def generate_scalability_report(
         plot_file_suffix=plot_file_suffix,
     )
 
+
     print()
-    print("#" * 8, "Epoch Time Report", "#" * 8)
-    print(epoch_time_table)
-    print()
-    print("#" * 8, "GPU Data Report", "#" * 8)
-    print(gpu_data_table)
-    print()
-    print("#" * 8, "Communication Data Report", "#" * 8)
-    print(communication_data_table)
-    print()
+    if epoch_time_table is not None:
+        print("#" * 8, "Epoch Time Report", "#" * 8)
+        print(epoch_time_table, "\n")
+    else: 
+        print("No Epoch Time Data Found\n")
+
+    if gpu_data_table is not None:
+        print("#" * 8, "GPU Data Report", "#" * 8)
+        print(gpu_data_table, "\n")
+    else: 
+        print("No GPU Data Found\n")
+
+    if communication_data_table is not None:
+        print("#" * 8, "Communication Data Report", "#" * 8)
+        print(communication_data_table, "\n")
+    else: 
+        print("No Communication Data Found\n")
 
 
 @app.command()

--- a/src/itwinai/scalability_report/data.py
+++ b/src/itwinai/scalability_report/data.py
@@ -54,9 +54,7 @@ def read_scalability_metrics_from_csv(
     dataframes = []
     for file_path in file_paths:
         df = pd.read_csv(file_path)
-        check_contains_columns(
-            df=df, expected_columns=expected_columns, file_path=file_path
-        )
+        check_contains_columns(df=df, expected_columns=expected_columns, file_path=file_path)
         dataframes.append(df)
 
     return pd.concat(dataframes)

--- a/src/itwinai/scalability_report/reports.py
+++ b/src/itwinai/scalability_report/reports.py
@@ -32,14 +32,14 @@ def epoch_time_report(
     backup_dir: Path,
     do_backup: bool = False,
     plot_file_suffix: str = ".png",
-) -> str:
+) -> str | None:
     """Generates reports and plots for epoch training times across distributed training
     strategies, including a log-log plot of absolute average epoch times against the
     number of GPUs and a log-log plot of relative speedup as more GPUs are added. The
     function optionally creates backups of the data.
 
     Args:
-        log_dirs (List[Path] | List[str]): List of path(s) to the directory containing CSV
+        log_dirs (List[Path] | List[str]): List of paths to the directory containing CSV
             files with epoch time metrics. The files must include the columns "name", "nodes",
             "epoch_id", and "time".
         plot_dir (Path | str): Path to the directory where the generated plots will
@@ -64,8 +64,11 @@ def epoch_time_report(
         )
         dataframes.append(temp_df)
     epoch_time_df = pd.concat(dataframes)
+    if epoch_time_df.empty:
+        return None
 
     # Calculate the average time per epoch for each strategy and number of nodes
+    print("\nAnalyzing Epoch Time Data...")
     avg_epoch_time_df = (
         epoch_time_df.groupby(["name", "nodes"])
         .agg(avg_epoch_time=("time", "mean"))
@@ -105,14 +108,14 @@ def gpu_data_report(
     backup_dir: Path,
     do_backup: bool = False,
     plot_file_suffix: str = ".png",
-) -> str:
+) -> str | None:
     """Generates reports and plots for GPU energy consumption and utilization across
     distributed training strategies. Includes bar plots for energy consumption and GPU
     utilization by strategy and number of GPUs. The function optionally creates backups
     of the data.
 
     Args:
-        log_dirs (List[Path] | List[str]): List of path(s) to the directory containing CSV
+        log_dirs (List[Path] | List[str]): List of paths to the directory containing CSV
             files with GPU data. The files must include the columns "sample_idx",
             "utilization", "power", "local_rank", "node_idx", "num_global_gpus", "strategy",
             and "probing_interval".
@@ -143,7 +146,10 @@ def gpu_data_report(
         )
         dataframes.append(temp_df)
     gpu_data_df = pd.concat(dataframes)
+    if gpu_data_df.empty:
+        return None
 
+    print("\nAnalyzing Epoch Time Data...")
     gpu_data_statistics_df = calculate_gpu_statistics(
         gpu_data_df=gpu_data_df, expected_columns=gpu_data_expected_columns
     )
@@ -188,14 +194,14 @@ def communication_data_report(
     backup_dir: Path,
     do_backup: bool = False,
     plot_file_suffix: str = ".png",
-) -> str:
+) -> str | None:
     """Generates reports and plots for communication and computation fractions across
     distributed training strategies. Includes a bar plot showing the fraction of time
     spent on computation vs communication for each strategy and GPU count. The function
     optionally creates backups of the data.
 
     Args:
-        log_dirs (List[Path] | List[str]): List of path(s) to the directory containing CSV
+        log_dirs (List[Path] | List[str]): List of paths to the directory containing CSV
             files with communication data. The files must include the columns "strategy",
             "num_gpus", "global_rank", "name", and "self_cuda_time_total".
         plot_dir (Path | str): Path to the directory where the generated plot will
@@ -222,6 +228,10 @@ def communication_data_report(
         )
         dataframes.append(temp_df)
     communication_data_df = pd.concat(dataframes)
+    if communication_data_df.empty:
+        return None
+
+    print("\nAnalyzing Communication Data...")
     computation_fraction_df = get_computation_fraction_data(communication_data_df)
 
     formatters = {"computation_fraction": lambda x: "{:.2f} %".format(x * 100)}

--- a/src/itwinai/scalability_report/reports.py
+++ b/src/itwinai/scalability_report/reports.py
@@ -81,7 +81,6 @@ def epoch_time_report(
     # Print the resulting table
     formatters = {"avg_epoch_time": "{:.2f} s".format}
     epoch_time_table = avg_epoch_time_df.to_string(index=False, formatters=formatters)
-    # print(epoch_time_table)
 
     # Create and save the figures
     absolute_fig, _ = absolute_avg_epoch_time_plot(avg_epoch_time_df=avg_epoch_time_df)

--- a/src/itwinai/scalability_report/reports.py
+++ b/src/itwinai/scalability_report/reports.py
@@ -10,6 +10,7 @@
 
 from pathlib import Path
 from typing import List
+
 import pandas as pd
 
 from itwinai.scalability_report.data import read_scalability_metrics_from_csv

--- a/src/itwinai/scalability_report/reports.py
+++ b/src/itwinai/scalability_report/reports.py
@@ -9,6 +9,8 @@
 # --------------------------------------------------------------------------------------
 
 from pathlib import Path
+from typing import List
+import pandas as pd
 
 from itwinai.scalability_report.data import read_scalability_metrics_from_csv
 from itwinai.scalability_report.plot import (
@@ -24,21 +26,21 @@ from itwinai.scalability_report.utils import (
 
 
 def epoch_time_report(
-    epoch_time_dir: Path | str,
+    log_dirs: List[Path] | List[str], 
     plot_dir: Path | str,
     backup_dir: Path,
     do_backup: bool = False,
     plot_file_suffix: str = ".png",
-) -> None:
+) -> str:
     """Generates reports and plots for epoch training times across distributed training
     strategies, including a log-log plot of absolute average epoch times against the
     number of GPUs and a log-log plot of relative speedup as more GPUs are added. The
     function optionally creates backups of the data.
 
     Args:
-        epoch_time_dir (Path | str): Path to the directory containing CSV files with
-            epoch time metrics. The files must include the columns "name", "nodes",
-            "epoch_id", and "time".
+        # epoch_time_dir (Path | str): Path to the directory containing CSV files with
+        #     epoch time metrics. The files must include the columns "name", "nodes",
+        #     "epoch_id", and "time".
         plot_dir (Path | str): Path to the directory where the generated plots will
             be saved.
         backup_dir (Path): Path to the directory where backups of the data will be stored
@@ -46,15 +48,19 @@ def epoch_time_report(
         do_backup (bool): Whether to create a backup of the epoch time data in the
             `backup_dir`. Defaults to False.
     """
-    if isinstance(epoch_time_dir, str):
-        epoch_time_dir = Path(epoch_time_dir)
     if isinstance(plot_dir, str):
         plot_dir = Path(plot_dir)
 
     epoch_time_expected_columns = {"name", "nodes", "epoch_id", "time"}
-    epoch_time_df = read_scalability_metrics_from_csv(
-        data_dir=epoch_time_dir, expected_columns=epoch_time_expected_columns
-    )
+
+    # Reading data from all the logdirs and concatenating the results
+    dataframes = []
+    for log_dir in log_dirs:
+        temp_df = read_scalability_metrics_from_csv(
+            data_dir=log_dir, expected_columns=epoch_time_expected_columns
+        )
+        dataframes.append(temp_df)
+    epoch_time_df = pd.concat(dataframes)
 
     # Calculate the average time per epoch for each strategy and number of nodes
     avg_epoch_time_df = (
@@ -66,7 +72,7 @@ def epoch_time_report(
     # Print the resulting table
     formatters = {"avg_epoch_time": "{:.2f} s".format}
     epoch_time_table = avg_epoch_time_df.to_string(index=False, formatters=formatters)
-    print(epoch_time_table)
+    # print(epoch_time_table)
 
     # Create and save the figures
     absolute_fig, _ = absolute_avg_epoch_time_plot(avg_epoch_time_df=avg_epoch_time_df)
@@ -81,21 +87,22 @@ def epoch_time_report(
     print(f"Saved relative average time plot at '{relative_speedup_plot_path.resolve()}'.")
 
     if not do_backup:
-        return
+        return epoch_time_table
 
     backup_dir.mkdir(exist_ok=True, parents=True)
     backup_path = backup_dir / "epoch_time_data.csv"
     epoch_time_df.to_csv(backup_path)
     print(f"Storing backup file at '{backup_path.resolve()}'.")
+    return epoch_time_table
 
 
 def gpu_data_report(
-    gpu_data_dir: Path | str,
+    log_dirs: List[Path] | List[str],
     plot_dir: Path | str,
     backup_dir: Path,
     do_backup: bool = False,
     plot_file_suffix: str = ".png",
-) -> None:
+) -> str:
     """Generates reports and plots for GPU energy consumption and utilization across
     distributed training strategies. Includes bar plots for energy consumption and GPU
     utilization by strategy and number of GPUs. The function optionally creates backups
@@ -115,6 +122,7 @@ def gpu_data_report(
     """
     if isinstance(plot_dir, str):
         plot_dir = Path(plot_dir)
+
     gpu_data_expected_columns = {
         "sample_idx",
         "utilization",
@@ -125,9 +133,14 @@ def gpu_data_report(
         "strategy",
         "probing_interval",
     }
-    gpu_data_df = read_scalability_metrics_from_csv(
-        data_dir=gpu_data_dir, expected_columns=gpu_data_expected_columns
-    )
+    dataframes = []
+    for log_dir in log_dirs:
+        temp_df = read_scalability_metrics_from_csv(
+            data_dir=log_dir, expected_columns=gpu_data_expected_columns
+        )
+        dataframes.append(temp_df)
+    gpu_data_df = pd.concat(dataframes)
+
     gpu_data_statistics_df = calculate_gpu_statistics(
         gpu_data_df=gpu_data_df, expected_columns=gpu_data_expected_columns
     )
@@ -136,7 +149,6 @@ def gpu_data_report(
         "utilization": "{:.2f} %".format,
     }
     gpu_data_table = gpu_data_statistics_df.to_string(index=False, formatters=formatters)
-    print(gpu_data_table)
 
     energy_plot_path = plot_dir / ("gpu_energy_plot" + plot_file_suffix)
     utilization_plot_path = plot_dir / ("utilization_plot" + plot_file_suffix)
@@ -158,21 +170,22 @@ def gpu_data_report(
     print(f"Saved utilization plot at '{utilization_plot_path.resolve()}'.")
 
     if not do_backup:
-        return
+        return gpu_data_table
 
     backup_dir.mkdir(exist_ok=True, parents=True)
     backup_path = backup_dir / "gpu_data.csv"
     gpu_data_df.to_csv(backup_path)
     print(f"Storing backup file at '{backup_path.resolve()}'.")
+    return gpu_data_table
 
 
 def communication_data_report(
-    communication_data_dir: Path | str,
+    log_dirs: List[Path] | List[str],
     plot_dir: Path | str,
     backup_dir: Path,
     do_backup: bool = False,
     plot_file_suffix: str = ".png",
-) -> None:
+) -> str:
     """Generates reports and plots for communication and computation fractions across
     distributed training strategies. Includes a bar plot showing the fraction of time
     spent on computation vs communication for each strategy and GPU count. The function
@@ -199,17 +212,19 @@ def communication_data_report(
         "name",
         "self_cuda_time_total",
     }
-    communication_data_df = read_scalability_metrics_from_csv(
-        data_dir=communication_data_dir,
-        expected_columns=communication_data_expected_columns,
-    )
+    dataframes = []
+    for log_dir in log_dirs:
+        temp_df = read_scalability_metrics_from_csv(
+            data_dir=log_dir, expected_columns=communication_data_expected_columns
+        )
+        dataframes.append(temp_df)
+    communication_data_df = pd.concat(dataframes)
     computation_fraction_df = get_computation_fraction_data(communication_data_df)
 
     formatters = {"computation_fraction": lambda x: "{:.2f} %".format(x * 100)}
     communication_data_table = computation_fraction_df.to_string(
         index=False, formatters=formatters
     )
-    print(communication_data_table)
 
     computation_fraction_plot_path = plot_dir / (
         "computation_fraction_plot" + plot_file_suffix
@@ -219,9 +234,10 @@ def communication_data_report(
     print(f"Saved computation fraction plot at '{computation_fraction_plot_path.resolve()}'.")
 
     if not do_backup:
-        return
+        return communication_data_table
 
     backup_dir.mkdir(exist_ok=True, parents=True)
     backup_path = backup_dir / "communication_data.csv"
     communication_data_df.to_csv(backup_path)
     print(f"Storing backup file at '{backup_path.resolve()}'.")
+    return communication_data_table

--- a/src/itwinai/scalability_report/reports.py
+++ b/src/itwinai/scalability_report/reports.py
@@ -39,15 +39,17 @@ def epoch_time_report(
     function optionally creates backups of the data.
 
     Args:
-        # epoch_time_dir (Path | str): Path to the directory containing CSV files with
-        #     epoch time metrics. The files must include the columns "name", "nodes",
-        #     "epoch_id", and "time".
+        log_dirs (List[Path] | List[str]): List of path(s) to the directory containing CSV
+            files with epoch time metrics. The files must include the columns "name", "nodes",
+            "epoch_id", and "time".
         plot_dir (Path | str): Path to the directory where the generated plots will
             be saved.
         backup_dir (Path): Path to the directory where backups of the data will be stored
             if `do_backup` is True.
         do_backup (bool): Whether to create a backup of the epoch time data in the
             `backup_dir`. Defaults to False.
+        plot_file_suffix (str): Suffix for the plot file names. Defaults to ".png".
+
     """
     if isinstance(plot_dir, str):
         plot_dir = Path(plot_dir)
@@ -110,10 +112,10 @@ def gpu_data_report(
     of the data.
 
     Args:
-        gpu_data_dir (Path | str): Path to the directory containing CSV files with GPU
-            data. The files must include the columns "sample_idx", "utilization",
-            "power", "local_rank", "node_idx", "num_global_gpus", "strategy", and
-            "probing_interval".
+        log_dirs (List[Path] | List[str]): List of path(s) to the directory containing CSV
+            files with GPU data. The files must include the columns "sample_idx",
+            "utilization", "power", "local_rank", "node_idx", "num_global_gpus", "strategy",
+            and "probing_interval".
         plot_dir (Path | str): Path to the directory where the generated plots will
             be saved.
         backup_dir (Path): Path to the directory where backups of the data will be stored
@@ -193,8 +195,8 @@ def communication_data_report(
     optionally creates backups of the data.
 
     Args:
-        communication_data_dir (Path | str): Path to the directory containing CSV files
-            with communication data. The files must include the columns "strategy",
+        log_dirs (List[Path] | List[str]): List of path(s) to the directory containing CSV
+            files with communication data. The files must include the columns "strategy",
             "num_gpus", "global_rank", "name", and "self_cuda_time_total".
         plot_dir (Path | str): Path to the directory where the generated plot will
             be saved.

--- a/src/itwinai/scalability_report/reports.py
+++ b/src/itwinai/scalability_report/reports.py
@@ -26,7 +26,7 @@ from itwinai.scalability_report.utils import (
 
 
 def epoch_time_report(
-    log_dirs: List[Path] | List[str], 
+    log_dirs: List[Path] | List[str],
     plot_dir: Path | str,
     backup_dir: Path,
     do_backup: bool = False,

--- a/src/itwinai/scalability_report/reports.py
+++ b/src/itwinai/scalability_report/reports.py
@@ -60,8 +60,6 @@ def epoch_time_report(
     # Reading data from all the logdirs and concatenating the results
     dataframes = []
     for log_dir in log_dir_paths:
-        if not log_dir.exists():
-            continue
         temp_df = read_scalability_metrics_from_csv(
             data_dir=log_dir, expected_columns=epoch_time_expected_columns
         )
@@ -144,8 +142,6 @@ def gpu_data_report(
     log_dir_paths = [Path(logdir) for logdir in log_dirs]
     dataframes = []
     for log_dir in log_dir_paths:
-        if not log_dir.exists():
-            continue
         temp_df = read_scalability_metrics_from_csv(
             data_dir=log_dir, expected_columns=gpu_data_expected_columns
         )
@@ -229,8 +225,6 @@ def communication_data_report(
     log_dir_paths = [Path(logdir) for logdir in log_dirs]
     dataframes = []
     for log_dir in log_dir_paths:
-        if not log_dir.exists():
-            continue
         temp_df = read_scalability_metrics_from_csv(
             data_dir=log_dir, expected_columns=communication_data_expected_columns
         )

--- a/src/itwinai/scalability_report/reports.py
+++ b/src/itwinai/scalability_report/reports.py
@@ -53,19 +53,22 @@ def epoch_time_report(
     """
     if isinstance(plot_dir, str):
         plot_dir = Path(plot_dir)
+    log_dir_paths = [Path(logdir) for logdir in log_dirs]
 
     epoch_time_expected_columns = {"name", "nodes", "epoch_id", "time"}
 
     # Reading data from all the logdirs and concatenating the results
     dataframes = []
-    for log_dir in log_dirs:
+    for log_dir in log_dir_paths:
+        if not log_dir.exists():
+            continue
         temp_df = read_scalability_metrics_from_csv(
             data_dir=log_dir, expected_columns=epoch_time_expected_columns
         )
         dataframes.append(temp_df)
-    epoch_time_df = pd.concat(dataframes)
-    if epoch_time_df.empty:
+    if not dataframes:
         return None
+    epoch_time_df = pd.concat(dataframes)
 
     # Calculate the average time per epoch for each strategy and number of nodes
     print("\nAnalyzing Epoch Time Data...")
@@ -139,15 +142,18 @@ def gpu_data_report(
         "strategy",
         "probing_interval",
     }
+    log_dir_paths = [Path(logdir) for logdir in log_dirs]
     dataframes = []
-    for log_dir in log_dirs:
+    for log_dir in log_dir_paths:
+        if not log_dir.exists():
+            continue
         temp_df = read_scalability_metrics_from_csv(
             data_dir=log_dir, expected_columns=gpu_data_expected_columns
         )
         dataframes.append(temp_df)
-    gpu_data_df = pd.concat(dataframes)
-    if gpu_data_df.empty:
+    if not dataframes:
         return None
+    gpu_data_df = pd.concat(dataframes)
 
     print("\nAnalyzing Epoch Time Data...")
     gpu_data_statistics_df = calculate_gpu_statistics(
@@ -221,15 +227,18 @@ def communication_data_report(
         "name",
         "self_cuda_time_total",
     }
+    log_dir_paths = [Path(logdir) for logdir in log_dirs]
     dataframes = []
-    for log_dir in log_dirs:
+    for log_dir in log_dir_paths:
+        if not log_dir.exists():
+            continue
         temp_df = read_scalability_metrics_from_csv(
             data_dir=log_dir, expected_columns=communication_data_expected_columns
         )
         dataframes.append(temp_df)
-    communication_data_df = pd.concat(dataframes)
-    if communication_data_df.empty:
+    if not dataframes:
         return None
+    communication_data_df = pd.concat(dataframes)
 
     print("\nAnalyzing Communication Data...")
     computation_fraction_df = get_computation_fraction_data(communication_data_df)

--- a/src/itwinai/torch/monitoring/monitoring.py
+++ b/src/itwinai/torch/monitoring/monitoring.py
@@ -175,7 +175,7 @@ def measure_gpu_utilization(method: Callable) -> Callable:
 
         global_utilization_log = strategy.gather_obj(local_utilization_log, dst_rank=0)
         if strategy.is_main_worker:
-            output_dir = Path("scalability-metrics/gpu-energy-data")
+            output_dir = Path(f"scalability-metrics/{self.run_id}/gpu-energy-data")
             output_dir.mkdir(exist_ok=True, parents=True)
             output_path = output_dir / f"{strategy_name}_{num_global_gpus}.csv"
 

--- a/src/itwinai/torch/profiling/profiler.py
+++ b/src/itwinai/torch/profiling/profiler.py
@@ -124,7 +124,7 @@ def profile_torch_trainer(method: Callable) -> Callable:
         profiling_dataframe["num_gpus"] = num_gpus_global
         profiling_dataframe["global_rank"] = global_rank
 
-        profiling_log_dir = Path("scalability-metrics/communication-data")
+        profiling_log_dir = Path(f"scalability-metrics/{self.run_id}/communication-data")
         profiling_log_dir.mkdir(parents=True, exist_ok=True)
 
         filename = f"{strategy_name}_{num_gpus_global}_{global_rank}.csv"

--- a/src/itwinai/torch/trainer.py
+++ b/src/itwinai/torch/trainer.py
@@ -123,7 +123,13 @@ class TorchTrainer(Trainer, LogMixin):
     #: PyTorch Profiler for communication vs. computation comparison
     profiler: Any | None
 
+    #: Toggles for the profilers
     measure_gpu_data: bool = False
+    measure_communication_overhead: bool = False
+    measure_epoch_time: bool = False
+
+    #: Run ID
+    run_id: str 
 
     def __init__(
         self,
@@ -144,7 +150,8 @@ class TorchTrainer(Trainer, LogMixin):
         profiling_warmup_epochs: int = 2,
         measure_gpu_data: bool = False,
         measure_communication_overhead: bool = False,
-        measure_epoch_time: bool = False
+        measure_epoch_time: bool = False,
+        run_id: str | None = None
     ) -> None:
         super().__init__(name)
         self.save_parameters(**self.locals2params(locals()))
@@ -174,6 +181,9 @@ class TorchTrainer(Trainer, LogMixin):
         self.measure_communication_overhead = measure_communication_overhead
         self.measure_epoch_time = measure_epoch_time
 
+        if run_id is None:
+            run_id = "run0"
+        self.run_id = run_id
 
     @property
     def strategy(self) -> TorchDistributedStrategy:
@@ -565,7 +575,7 @@ class TorchTrainer(Trainer, LogMixin):
                     " when running distributed training!"
                 )
             num_nodes = int(os.environ["SLURM_NNODES"])
-            epoch_time_output_dir = Path("scalability-metrics/epoch-time")
+            epoch_time_output_dir = Path(f"scalability-metrics/{self.run_id}/epoch-time")
             epoch_time_file_name = f"epochtime_{self.strategy.name}_{num_nodes}N.csv"
             epoch_time_output_path = epoch_time_output_dir / epoch_time_file_name
 

--- a/use-cases/virgo/config.yaml
+++ b/use-cases/virgo/config.yaml
@@ -12,7 +12,7 @@
 hdf5_file_location: /p/scratch/intertwin/datasets/virgo_hdf5/virgo_data.hdf5
 hdf5_dataset_name: virgo_dataset
 data_root: ./data
-epochs: 15
+epochs: 5
 chunk_size: 1000 # equivalent to chunk size 
 batch_size: 64 # Note: not used for "training_pipeline"
 learning_rate: 0.0001
@@ -20,6 +20,7 @@ strategy: ddp
 checkpoint_path: checkpoints/epoch_{}.pth
 validation_proportion: 0.1
 rnd_seed: 42
+run_id: "run2"
 
 # To use the entire synthetic dataset that is generated prior to running the pipeline
 training_pipeline:
@@ -33,9 +34,10 @@ training_pipeline:
       chunk_size: ${chunk_size}
       hdf5_dataset_name: ${hdf5_dataset_name}
     - _target_: trainer.NoiseGeneratorTrainer
-      measure_gpu_data: False
+      measure_gpu_data: True
       measure_communication_overhead: False
-      measure_epoch_time: False
+      measure_epoch_time: True
+      run_id: ${run_id}
       config:
         generator: simple #unet
         batch_size: 1

--- a/use-cases/virgo/slurm_config.yaml
+++ b/use-cases/virgo/slurm_config.yaml
@@ -4,13 +4,13 @@
 # Default arguments can be seen in src/itwinai/slurm/utils.py
 
 mode: single # "single", "runall" or "scaling-test" - defaults to "single"
-dist_strat: deepspeed # "ddp", "deepspeed" or "horovod"
+dist_strat: ddp # "ddp", "deepspeed" or "horovod"
 
 account: intertwin
-time: 01:00:00
+time: 00:30:00
 partition: develbooster
 
-num_nodes: 2
+num_nodes: 1
 num_tasks_per_node: 1
 gpus_per_node: 4
 cpus_per_gpu: 4

--- a/use-cases/virgo/trainer.py
+++ b/use-cases/virgo/trainer.py
@@ -212,7 +212,7 @@ class NoiseGeneratorTrainer(TorchTrainer):
             # save_path
 
             num_nodes = int(os.environ.get("SLURM_NNODES", 1))
-            epoch_time_output_dir = Path("scalability-metrics/epoch-time")
+            epoch_time_output_dir = Path(f"scalability-metrics/{self.run_id}/epoch-time")
             epoch_time_file_name = f"epochtime_{self.strategy.name}_{num_nodes}N.csv"
             epoch_time_output_path = epoch_time_output_dir / epoch_time_file_name
             epoch_time_logger = EpochTimeTracker(


### PR DESCRIPTION
Right now, the scalability report only supports a single run. However, we have seen that the results we get can sometimes be affected by inconsistencies/noise. In particular, it seems like some of the assigned nodes can vary due to outside factors. Because of this, it would be nice to aggregate results across multiple runs. This PR adds this functionality both to the logging of metrics and to the creation of the report.

Example output when aggregating runs:
``` 
(itwinai) [saether1@jwlogin22 virgo]$ itwinai generate-scalability-report
run_id was not passed, so will aggregate data from all runs in the given directory: '/p/project1/intertwin/saether1/itwinai/use-cases/virgo/scalability-metrics'.
Adding data from scalability-metrics/run0!
Adding data from scalability-metrics/run1!

Analyzing Epoch Time Data...
Saved GPU energy plot at '/p/project1/intertwin/saether1/itwinai/use-cases/virgo/plots/gpu_energy_plot.png'.
Saved utilization plot at '/p/project1/intertwin/saether1/itwinai/use-cases/virgo/plots/utilization_plot.png'.

No Epoch Time Data Found

######## GPU Data Report ########
 strategy  num_global_gpus total_energy_wh utilization
torch-ddp                4       148.46 Wh     72.10 %

No Communication Data Found
```

Example output when choosing a particular run:
```
(itwinai) [saether1@jwlogin22 virgo]$ itwinai generate-scalability-report --run-id run0
Reading data using run_id: 'run0' at location '/p/project1/intertwin/saether1/itwinai/use-cases/virgo/scalability-metrics/run0'

Analyzing Epoch Time Data...
Saved GPU energy plot at '/p/project1/intertwin/saether1/itwinai/use-cases/virgo/plots/gpu_energy_plot.png'.
Saved utilization plot at '/p/project1/intertwin/saether1/itwinai/use-cases/virgo/plots/utilization_plot.png'.

No Epoch Time Data Found

######## GPU Data Report ########
 strategy  num_global_gpus total_energy_wh utilization
torch-ddp                4        75.18 Wh     71.70 %

No Communication Data Found
```

Example when aggregating runs with different metrics present: 
``` 
(itwinai) [saether1@jwlogin22 virgo]$ itwinai generate-scalability-report
run_id was not passed, so will aggregate data from all runs in the given directory: '/p/project1/intertwin/saether1/itwinai/use-cases/virgo/scalability-metrics'.
Adding data from scalability-metrics/run0!
Adding data from scalability-metrics/run1!
Adding data from scalability-metrics/run2!

Analyzing Epoch Time Data...
Saved absolute average time plot at '/p/project1/intertwin/saether1/itwinai/use-cases/virgo/plots/absolute_epoch_time.png'.
Saved relative average time plot at '/p/project1/intertwin/saether1/itwinai/use-cases/virgo/plots/relative_epoch_time_speedup.png'.

Analyzing Epoch Time Data...
Saved GPU energy plot at '/p/project1/intertwin/saether1/itwinai/use-cases/virgo/plots/gpu_energy_plot.png'.
Saved utilization plot at '/p/project1/intertwin/saether1/itwinai/use-cases/virgo/plots/utilization_plot.png'.

######## Epoch Time Report ########
     name  nodes avg_epoch_time
torch-ddp      1        56.27 s

######## GPU Data Report ########
 strategy  num_global_gpus total_energy_wh utilization
torch-ddp                4       221.09 Wh     72.01 %

No Communication Data Found
```