### PR TITLE
Fix Radio Astronomy deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,6 @@ conflicts = [[{ extra = "tf-cuda" }, { extra = "torch" }]]
 [tool.uv.sources]
 torch = [{ index = "pytorch-cu121", marker = "platform_system != 'Darwin'" }]
 torchvision = [{ index = "pytorch-cu121", marker = "platform_system != 'Darwin'" }]
-pulsardt = [{ index = "pulsar-dt"}]
 
 # Specific index for pytorch
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,20 +55,6 @@ dependencies = [
 # Has to be added as an optional dependency, when installed in non-AMD environments, the torch
 # import will fail as it tries to find the related AMD libs of amdsmi.
 amd = ["amdsmi>=6.4.0"]
-
-# dependencies that are not included by dev or torch
-# but needed for radio-astronomy.
-radio-astronomy = [
-  "pulsarrfi-nn @ git+https://gitlab.com/ml-ppa/pulsarrfi_nn.git@version_0.2#subdirectory=unet_semantic_segmentation",
-  "pulsardt @ git+https://gitlab.com/ml-ppa/pulsardt@main",
-  "ipywidgets",
-  "tqdm>=4.65.0",
-  "numpyencoder>=0.3.0",
-  "pyquaternion>=0.9.9",
-  "scikit-image>=0.22.0",
-  "pyqt6>=6.0",
-]
-
 torch = [
   "torch==2.4.*",
   "lightning>=2",
@@ -161,11 +147,6 @@ pulsardt = [{ index = "pulsar-dt"}]
 [[tool.uv.index]]
 name = "pytorch-cu121"
 url = "https://download.pytorch.org/whl/cu121"
-explicit = true
-
-[[tool.uv.index]]
-name = "pulsar-dt"
-url = "https://gitlab.com/api/v4/projects/59840702/packages/pypi/simple"
 explicit = true
 
 # Ruff configuration: https://docs.astral.sh/ruff/configuration/

--- a/use-cases/radio-astronomy/requirements.txt
+++ b/use-cases/radio-astronomy/requirements.txt
@@ -1,8 +1,8 @@
-numpyencoder
+numpyencoder>=0.3.0
 pulsarrfi-nn @ git+https://gitlab.com/ml-ppa/pulsarrfi_nn.git@version_0.2#subdirectory=unet_semantic_segmentation
 pulsardt @ git+https://gitlab.com/ml-ppa/pulsardt@main
 ipywidgets
-pyqt6
-pyquaternion
-scikit-image
-tqdm
+pyqt6>=6.0
+pyquaternion>=0.9.9
+scikit-image>=0.22.0
+tqdm>=4.65.0


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Removed RA deps from pyproject.toml because:

- git dependencies (`pip install git+...`) break the release process to PyPI
- this is consistent with how we did for the other use cases
- you can still use uv: `uv pip install -r requirements.txt`
---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
