### PR TITLE
[DRAFT] Lumi dev container

### DIFF
--- a/env-files/torch/README.md
+++ b/env-files/torch/README.md
@@ -2,14 +2,24 @@
 
 ## Singularity
 
-Example for LUMI (AMD GPUs):
+This example is for building the itwinai container for LUMI (AMD GPUs) locally (use `scp` to transfer the final image to LUMI)
+
+First navigate with `cd` to the base folder of itwinai.
+
+From there, download the singularity base image for pytorch with ROCm:
 
 ```bash
-sudo singularity build --tmpdir /mnt/mbunino/tmp /mnt/mbunino/container_test_3.sif env-files/torch/rocm.def
+singularity pull rocm-base-pytorch.sif oras://registry.egi.eu/dev.intertwin.eu/itwinai-dev:lumi-pytorch-rocm-6.1.3-python-3.12-pytorch-v2.4.1
 ```
 
-- `/mnt/mbunino/tmp` is a location with enough storage space to support the build.
+Then build the final container with:
 
-The Singularity definition file above is bootstrapping from a Singularity image co-developed
+```bash
+sudo singularity build --tmpdir /tmp itwinai-lumi-dev.sif env-files/torch/rocm.def
+```
+
+- `/tmp` is a location with enough storage space to support the build.
+
+The Singularity definition file above is bootstrapping from the Singularity image (`rocm-base-pytorch.sif`) co-developed
 by LUMI and AMD, which is mirrored on the interTwin containers registry at
 `registry.egi.eu/dev.intertwin.eu/itwinai-dev:lumi-pytorch-rocm-6.1.3-python-3.12-pytorch-v2.4.1`

--- a/env-files/torch/rocm.def
+++ b/env-files/torch/rocm.def
@@ -5,17 +5,18 @@
 #
 # Credit:
 # - Matteo Bunino <matteo.bunino@cern.ch> - CERN
+# - Linus Eickhoff <linus.maximilian.eickhoff@cern.ch> - CERN
 # --------------------------------------------------------------------------------------
 
 # Singularity definition file for ROCm with PyTorch, starting from ROCm base image provided
-# by LUMI and AMD.
+# by LUMI and AMD. Allows for editable installation of the itwinai project.
 
-Bootstrap: docker
-From: registry.egi.eu/dev.intertwin.eu/itwinai-dev:lumi-pytorch-rocm-6.1.3-python-3.12-pytorch-v2.4.1
+# acquire the base image for rocm pytorch for lumi:
+# singularity pull rocm-base-pytorch.sif oras://registry.egi.eu/dev.intertwin.eu/itwinai-dev:lumi-pytorch-rocm-6.1.3-python-3.12-pytorch-v2.4.1
 
-# # To build from local image
-# Bootstrap: localimage
-# From: /path/to/base.sif
+# To build from local image
+Bootstrap: localimage
+From: rocm-base-pytorch.sif
 
 %files
     pyproject.toml /app/pyproject.toml
@@ -81,8 +82,8 @@ From: registry.egi.eu/dev.intertwin.eu/itwinai-dev:lumi-pytorch-rocm-6.1.3-pytho
     # ------------------------------------------------------------------
     cd /app
 
-    pip install --no-cache-dir --no-binary=horovod \
-        .[torch,amd] \
+    pip install -e --no-cache-dir --no-binary=horovod \
+        .[torch,dev,amd] \
         --extra-index-url https://download.pytorch.org/whl/rocm6.1 \
         "prov4ml[amd]@git+https://github.com/matbun/ProvML@new-main" \
         pytest pytest-xdist psutil wheel

--- a/env-files/torch/rocm.def
+++ b/env-files/torch/rocm.def
@@ -11,7 +11,7 @@
 # Singularity definition file for ROCm with PyTorch, starting from ROCm base image provided
 # by LUMI and AMD. Allows for editable installation of the itwinai project.
 
-# acquire the base image for rocm pytorch for lumi:
+# Acquire the base image for rocm pytorch for lumi, by running the following command in the terminal:
 # singularity pull rocm-base-pytorch.sif oras://registry.egi.eu/dev.intertwin.eu/itwinai-dev:lumi-pytorch-rocm-6.1.3-python-3.12-pytorch-v2.4.1
 
 # To build from local image
@@ -64,6 +64,7 @@ From: rocm-base-pytorch.sif
     export CXX=/usr/bin/g++-11
     export CXXFLAGS="-std=c++17"
 
+
     # clone + patch + build wheel (j16 keeps image build time reasonable)
     git clone --recursive https://github.com/horovod/horovod.git \
         && cd horovod \
@@ -82,7 +83,8 @@ From: rocm-base-pytorch.sif
     # ------------------------------------------------------------------
     cd /app
 
-    pip install -e --no-cache-dir --no-binary=horovod \
+    # Install in editable mode. For development on LUMI, mount the src directory to /app/src.
+    pip install --no-cache-dir --no-binary=horovod -e \
         .[torch,dev,amd] \
         --extra-index-url https://download.pytorch.org/whl/rocm6.1 \
         "prov4ml[amd]@git+https://github.com/matbun/ProvML@new-main" \
@@ -91,7 +93,7 @@ From: rocm-base-pytorch.sif
 %labels
     Author Matteo Bunino
     Project interTwin - itwinai
-    Version 0.3.1
+    Version 0.3.2
 
 %test
     # Activate conda env

--- a/use-cases/mnist/torch/runall.lumi.sh
+++ b/use-cases/mnist/torch/runall.lumi.sh
@@ -10,7 +10,7 @@
 # - Linus Eickhoff <linus.maximilian.eickhoff@cern.ch> - CERN
 # --------------------------------------------------------------------------------------
 
-export CONTAINER_PATH="/project/project_465001592/itwinai-containers/container_test_5.sif"
+export CONTAINER_PATH="/project/project_465001592/itwinai-containers/itwinai-dev.sif"
 
 # Clear SLURM logs (*.out and *.err files)
 rm -rf logs_slurm checkpoints* mllogs* ray_checkpoints logs_torchrun


### PR DESCRIPTION
made lumi container suitable for development (installing in editable mode). Fixed base image retrieval (assumed docker file, and did not previously work, as the base image for lumi and pytorch was a SIF). Added solution as comments and to README