### PR TITLE
Speedup singularity push

### DIFF
--- a/ci/src/main/hpc.py
+++ b/ci/src/main/hpc.py
@@ -83,7 +83,7 @@ rm -rf oras_${ORAS_VERSION}_linux_amd64.tar.gz /usr/local/oras-install
         uri: Annotated[str, Doc("Target URI for the image")],
         concurrency: Annotated[
             int, Doc("Number of parallel threads used during image push")
-        ] = 5,
+        ] = 10,
     ) -> str:
         """Export container and publish it to some registry using oras push (using
         concurrency).


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Currently, in the container CI the bottleneck is the operation of pushing a singularity image to a remote registry (almost 2 hours for images large about 4GB -- [example](https://dagger.cloud/itwinai/traces/07b31ed071699ee510009927a828cd26?listen=5371facf3821093e&listen=ed896f5a1fe677d5)).
This PR tries to reduce this bottleneck by using `oras push`, which allows for some degree of concurrency during the push (this PR tries with 10 parallel threads).
By default it will use 10 threads. Tested locally and it worked. Let's see on GHA...

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
