### PR TITLE
Update exec-pipeline and fix tests

### DIFF
--- a/src/itwinai/cli.py
+++ b/src/itwinai/cli.py
@@ -26,11 +26,11 @@ import subprocess
 import sys
 from pathlib import Path
 from textwrap import dedent
-from typing import List, Optional
+from typing import List
 
 import hydra
-from omegaconf import DictConfig
 import typer
+from omegaconf import DictConfig
 from typing_extensions import Annotated
 
 from itwinai.utils import COMPUTATION_DATA_DIR, EPOCH_TIME_DIR, GPU_ENERGY_DIR
@@ -630,7 +630,7 @@ def exec_pipeline(
         ),
     ] = "",
     overrides: Annotated[
-        Optional[List[str]],
+        List[str] | None,
         typer.Argument(
             help=(
                 "Any key=value arguments to override config values "
@@ -675,6 +675,7 @@ def exec_pipeline_with_compose(cfg: DictConfig):
 
     from hydra.utils import instantiate
     from omegaconf import OmegaConf
+
     from itwinai.utils import filter_pipeline_steps
 
     # Register custom OmegaConf resolver to allow to dynaimcally compute the current working

--- a/src/itwinai/cli.py
+++ b/src/itwinai/cli.py
@@ -684,14 +684,14 @@ def exec_pipeline_with_compose(cfg: DictConfig):
             return list(range(int(x)))
         return list(range(int(x), int(y), int(step)))
 
-    if OmegaConf.has_resolver("itwinai.range"):
+    if not OmegaConf.has_resolver("itwinai.range"):
         OmegaConf.register_new_resolver("itwinai.range", range_resolver)
-    if OmegaConf.has_resolver("itwinai.multiply"):
+    if not OmegaConf.has_resolver("itwinai.multiply"):
         OmegaConf.register_new_resolver("itwinai.multiply", lambda x, y: x * y)
 
     # Register custom OmegaConf resolver to allow to dynaimcally compute the current working
     # directory. Example: some_field: ${itwinai.cwd:}/some/nested/path/in/current/working/dir
-    if OmegaConf.has_resolver("itwinai.cwd"):
+    if not OmegaConf.has_resolver("itwinai.cwd"):
         OmegaConf.register_new_resolver("itwinai.cwd", os.getcwd)
 
     pipe_steps = OmegaConf.select(cfg, "pipe_steps", default=None)

--- a/src/itwinai/cli.py
+++ b/src/itwinai/cli.py
@@ -689,7 +689,7 @@ def exec_pipeline_with_compose(cfg: DictConfig):
     if not OmegaConf.has_resolver("itwinai.multiply"):
         OmegaConf.register_new_resolver("itwinai.multiply", lambda x, y: x * y)
 
-    # Register custom OmegaConf resolver to allow to dynaimcally compute the current working
+    # Register custom OmegaConf resolver to allow dynamically computing the current working
     # directory. Example: some_field: ${itwinai.cwd:}/some/nested/path/in/current/working/dir
     if not OmegaConf.has_resolver("itwinai.cwd"):
         OmegaConf.register_new_resolver("itwinai.cwd", os.getcwd)

--- a/src/itwinai/cli.py
+++ b/src/itwinai/cli.py
@@ -678,18 +678,21 @@ def exec_pipeline_with_compose(cfg: DictConfig):
 
     from itwinai.utils import filter_pipeline_steps
 
-    # Register custom OmegaConf resolver to allow to dynaimcally compute the current working
-    # directory. Example: some_field: ${itwinai.cwd:}/some/nested/path/in/current/working/dir
-    OmegaConf.register_new_resolver("itwinai.cwd", os.getcwd)
-
     def range_resolver(x, y=None, step=1):
         """Custom OmegaConf resolver for range."""
         if y is None:
             return list(range(int(x)))
         return list(range(int(x), int(y), int(step)))
 
-    OmegaConf.register_new_resolver("itwinai.range", range_resolver)
-    OmegaConf.register_new_resolver("itwinai.multiply", lambda x, y: x * y)
+    if OmegaConf.has_resolver("itwinai.range"):
+        OmegaConf.register_new_resolver("itwinai.range", range_resolver)
+    if OmegaConf.has_resolver("itwinai.multiply"):
+        OmegaConf.register_new_resolver("itwinai.multiply", lambda x, y: x * y)
+
+    # Register custom OmegaConf resolver to allow to dynaimcally compute the current working
+    # directory. Example: some_field: ${itwinai.cwd:}/some/nested/path/in/current/working/dir
+    if OmegaConf.has_resolver("itwinai.cwd"):
+        OmegaConf.register_new_resolver("itwinai.cwd", os.getcwd)
 
     pipe_steps = OmegaConf.select(cfg, "pipe_steps", default=None)
     pipe_key = OmegaConf.select(cfg, "pipe_key", default="training_pipeline")

--- a/src/itwinai/tests/dummy_components.py
+++ b/src/itwinai/tests/dummy_components.py
@@ -52,6 +52,7 @@ class FakePreproc(BaseComponent):
         self.save_parameters(max_items=max_items, name=name)
         self.max_items = max_items
 
+    @monitor_exec
     def execute(self): ...
 
 
@@ -68,6 +69,7 @@ class FakeTrainer(BaseComponent):
         self.lr = lr
         self.batch_size = batch_size
 
+    @monitor_exec
     def execute(self): ...
 
 

--- a/src/itwinai/utils.py
+++ b/src/itwinai/utils.py
@@ -18,14 +18,13 @@ import sys
 import time
 import warnings
 from collections.abc import MutableMapping
-from omegaconf import DictConfig
 from pathlib import Path
 from typing import Any, Callable, Dict, Hashable, List, Tuple, Type
 from urllib.parse import urlparse
 
-from omegaconf import DictConfig, errors, ListConfig
-import yaml
 import typer
+import yaml
+from omegaconf import DictConfig, ListConfig, errors
 
 from .loggers import Logger
 

--- a/src/itwinai/utils.py
+++ b/src/itwinai/utils.py
@@ -368,7 +368,9 @@ def filter_pipeline_steps(pipeline_cfg: DictConfig, pipe_steps: List[Any]) -> No
     """
     if "steps" not in pipeline_cfg:
         py_logger.error(
-            "'pipe_steps' were passed but the given pipe key does not contain 'steps'."
+            "Pipelines have to contain the key `steps`, but the given pipeline does not. Make"
+            " sure that your pipeline has at least one step. Are you sure you used the right"
+            " pipe key?"
         )
         raise typer.Exit(1)
 
@@ -384,7 +386,7 @@ def filter_pipeline_steps(pipeline_cfg: DictConfig, pipe_steps: List[Any]) -> No
         py_logger.error(
             "The steps in the given pipeline are unnamed, but some of the `pipe_steps` are"
             " named. This is not supported. Use indices to filter steps when the steps are"
-            "unnamed."
+            " unnamed."
         )
         raise typer.Exit(1)
 
@@ -394,8 +396,7 @@ def filter_pipeline_steps(pipeline_cfg: DictConfig, pipe_steps: List[Any]) -> No
     except errors.ConfigKeyError:
         py_logger.error(
             "Could not find all selected steps. Please ensure that all steps exist and that"
-            f"you provided to the dotpath to them. \n\tSteps provided: {pipe_steps}."
+            f" you provided to the dotpath to them. \n\tSteps provided: {pipe_steps}."
             f"\n\tValid steps: {pipeline_cfg.steps.keys()}"
         )
         raise typer.Exit(1)
-

--- a/tests/components/test_config_parsing.py
+++ b/tests/components/test_config_parsing.py
@@ -68,7 +68,7 @@ def test_instantiate_and_execute_pipeline(pipe_key, temp_yaml_files, monkeypatch
     ):
         path = temp_yaml_files[pipe_key]
         args = [
-            "exec_pipeline",
+            "itwinai exec_pipeline", # This doesn't actually do anything
             f"--config-dir={path.parent}",
             f"--config-path={path.parent}",
             f"--config-name={path.stem}",
@@ -102,7 +102,7 @@ def test_step_selection_list_pipeline(temp_yaml_files, monkeypatch):
         pipe_key="my-list-pipeline"
         path = temp_yaml_files[pipe_key]
         args = [
-            "exec_pipeline",
+            "itwinai exec_pipeline", # This doesn't actually do anything
             f"--config-dir={path.parent}",
             f"--config-path={path.parent}",
             f"--config-name={path.stem}",
@@ -137,7 +137,7 @@ def test_step_selection_dict_pipeline(temp_yaml_files, monkeypatch):
         pipe_key="my-dict-pipeline"
         path = temp_yaml_files[pipe_key]
         args = [
-            "exec_pipeline",
+            "itwinai exec_pipeline", # This doesn't actually do anything
             f"--config-dir={path.parent}",
             f"--config-path={path.parent}",
             f"--config-name={path.stem}",
@@ -168,7 +168,7 @@ def test_dynamic_override_interpolation_list_pipeline(temp_yaml_files, monkeypat
         path = temp_yaml_files[pipe_key]
 
         args = [
-            "exec_pipeline",
+            "itwinai exec_pipeline", # This doesn't actually do anything
             f"--config-path={path.parent}",
             f"--config-dir={path.parent}",
             f"--config-name={path.stem}",
@@ -193,7 +193,7 @@ def test_dynamic_override_cli_dict_pipeline(temp_yaml_files, monkeypatch):
         pipe_key = 'my-dict-pipeline'
         path = temp_yaml_files[pipe_key]
         args = [
-            "exec_pipeline",
+            "itwinai exec_pipeline", # This doesn't actually do anything
             f"--config-path={path.parent}",
             f"--config-dir={path.parent}",
             f"--config-name={path.stem}",
@@ -210,6 +210,7 @@ def test_invalid_step_selection(temp_yaml_files, monkeypatch):
     """Test that a call to exec_pipeline throws a 'ConfigKeyError' error if it is called
     with an invalid step to select."""
     args = [
+        "itwinai exec_pipeline", # This doesn't actually do anything
         f"--config-path={temp_yaml_files['my-dict-pipeline']}",
         "pipe_key=my-dict-pipeline",
         "+pipe_steps=[non-existent-step]",
@@ -225,6 +226,7 @@ def test_invalid_pipeline_key(temp_yaml_files, monkeypatch):
     """Test that a call to exec_pipeline throws a 'MissingMandatoryValue' error if it is called
     with an invalid pipeline key to select"""
     args = [
+        "itwinai exec_pipeline", # This doesn't actually do anything
         f"--config-path={temp_yaml_files['my-dict-pipeline']}",
         "pipe_key=non-existent-pipeline",
     ]

--- a/tests/components/test_config_parsing.py
+++ b/tests/components/test_config_parsing.py
@@ -85,19 +85,7 @@ def test_instantiate_and_execute_pipeline(pipe_key, temp_yaml_files, monkeypatch
         mock_trainer_init.assert_called_once_with(lr=0.001, batch_size=32, name="my-trainer")
         mock_trainer_exec.assert_called_once()
 
-
-@pytest.mark.parametrize(
-    "pipe_key",
-    [
-        "my-list-pipeline",
-        "my-dict-pipeline",
-        "some.field.my-nested-pipeline",
-        "my-interpolation-pipeline",
-    ],
-)
-def test_step_selection(pipe_key, temp_yaml_files, monkeypatch):
-    """Test that exec_pipeline can correctly select steps via cli arguments and instantiate
-    and execute only the selected steps from the pipeline."""
+def test_step_selection_list_pipeline(temp_yaml_files, monkeypatch):
     with (
         patch(
             "itwinai.tests.dummy_components.FakePreproc.__init__", return_value=None
@@ -112,6 +100,7 @@ def test_step_selection(pipe_key, temp_yaml_files, monkeypatch):
             "itwinai.tests.dummy_components.FakeTrainer.execute", return_value=None
         ) as mock_trainer_exec,
     ):
+        pipe_key="my-list-pipeline"
         path = temp_yaml_files[pipe_key]
         args = [
             "exec_pipeline",
@@ -125,12 +114,46 @@ def test_step_selection(pipe_key, temp_yaml_files, monkeypatch):
 
         exec_pipeline()
 
-        mock_preproc_init.assert_called_once_with(max_items=33, name="my-preproc")
-        mock_preproc_exec.assert_called_once()
+        mock_trainer_init.assert_called_once_with(lr=0.001, batch_size=32, name="my-trainer")
+        mock_trainer_exec.assert_called_once()
 
-        mock_trainer_init.assert_not_called()
-        mock_trainer_exec.assert_not_called()
+        mock_preproc_init.assert_not_called()
+        mock_preproc_exec.assert_not_called()
 
+def test_step_selection_dict_pipeline(temp_yaml_files, monkeypatch):
+    with (
+        patch(
+            "itwinai.tests.dummy_components.FakePreproc.__init__", return_value=None
+        ) as mock_preproc_init,
+        patch(
+            "itwinai.tests.dummy_components.FakePreproc.execute", return_value=None
+        ) as mock_preproc_exec,
+        patch(
+            "itwinai.tests.dummy_components.FakeTrainer.__init__", return_value=None
+        ) as mock_trainer_init,
+        patch(
+            "itwinai.tests.dummy_components.FakeTrainer.execute", return_value=None
+        ) as mock_trainer_exec,
+    ):
+        pipe_key="my-dict-pipeline"
+        path = temp_yaml_files[pipe_key]
+        args = [
+            "exec_pipeline",
+            f"--config-dir={path.parent}",
+            f"--config-path={path.parent}",
+            f"--config-name={path.stem}",
+            f"+pipe_key={pipe_key}",
+            "+pipe_steps=[train-step]",
+        ]
+        monkeypatch.setattr(sys, "argv", args)
+
+        exec_pipeline()
+
+        mock_trainer_init.assert_called_once_with(lr=0.001, batch_size=32, name="my-trainer")
+        mock_trainer_exec.assert_called_once()
+
+        mock_preproc_init.assert_not_called()
+        mock_preproc_exec.assert_not_called()
 
 
 def test_dynamic_override_interpolation_list_pipeline(temp_yaml_files, monkeypatch):
@@ -138,7 +161,6 @@ def test_dynamic_override_interpolation_list_pipeline(temp_yaml_files, monkeypat
     and execute the steps with the updated arguments. This tests the list pipeline with
     interpolation keys."""
     with (
-        pytest.raises(SystemExit) as sys_exit,
         patch(
             "itwinai.tests.dummy_components.FakeTrainer.__init__", return_value=None
         ) as mock_trainer_init,
@@ -150,7 +172,8 @@ def test_dynamic_override_interpolation_list_pipeline(temp_yaml_files, monkeypat
             "exec_pipeline",
             f"--config-path={path.parent}",
             f"--config-dir={path.parent}",
-            f"pipe_key={pipe_key}",
+            f"--config-name={path.stem}",
+            f"+pipe_key={pipe_key}",
             "lr=0.005",
             "my-interpolation-pipeline.steps.1.batch_size=64",
         ]
@@ -158,29 +181,30 @@ def test_dynamic_override_interpolation_list_pipeline(temp_yaml_files, monkeypat
         exec_pipeline()
 
         mock_trainer_init.assert_called_once_with(lr=0.005, batch_size=64, name="my-trainer")
-    assert sys_exit.value.code == 0, "Pipeline should run through without fail"
 
 
 def test_dynamic_override_cli_dict_pipeline(temp_yaml_files, monkeypatch):
     """Test that exec_pipeline can correctly set keys via cli override and instantiate
     and execute the steps with the updated arguments. This tests the dictionary pipeline."""
     with (
-        pytest.raises(SystemExit) as sys_exit,
         patch(
             "itwinai.tests.dummy_components.FakePreproc.__init__", return_value=None
         ) as mock_preproc_init,
     ):
+        pipe_key = 'my-dict-pipeline'
+        path = temp_yaml_files[pipe_key]
         args = [
             "exec_pipeline",
-            f"--config-path={temp_yaml_files['my-dict-pipeline']}",
-            "pipe_key=my-dict-pipeline",
+            f"--config-path={path.parent}",
+            f"--config-dir={path.parent}",
+            f"--config-name={path.stem}",
+            f"+pipe_key={pipe_key}",
             "my-dict-pipeline.steps.preproc-step.name=new-preproc",
         ]
         monkeypatch.setattr(sys, "argv", args)
         exec_pipeline()
 
         mock_preproc_init.assert_called_once_with(max_items=33, name="new-preproc")
-    assert sys_exit.value.code == 0, "Pipeline should run through without fail"
 
 
 def test_invalid_step_selection(temp_yaml_files, monkeypatch):

--- a/tests/components/test_config_parsing.py
+++ b/tests/components/test_config_parsing.py
@@ -41,121 +41,146 @@ def temp_yaml_files(tmp_path):
     return file_paths
 
 
-def test_instantiate_and_execute_pipeline(temp_yaml_files, monkeypatch):
+@pytest.mark.parametrize(
+    "pipe_key",
+    [
+        "my-list-pipeline",
+        "my-dict-pipeline",
+        "some.field.my-nested-pipeline",
+        "my-interpolation-pipeline",
+    ],
+)
+def test_instantiate_and_execute_pipeline(pipe_key, temp_yaml_files, monkeypatch):
     """Test that exec_pipeline correctly instantiates and executes all components of
     the pipeline."""
-    with pytest.raises(SystemExit):
-        with (
-            patch(
-                "itwinai.tests.dummy_components.FakePreproc.__init__", return_value=None
-            ) as mock_preproc_init,
-            patch(
-                "itwinai.tests.dummy_components.FakePreproc.execute", return_value=None
-            ) as mock_preproc_exec,
-            patch(
-                "itwinai.tests.dummy_components.FakeTrainer.__init__", return_value=None
-            ) as mock_trainer_init,
-            patch(
-                "itwinai.tests.dummy_components.FakeTrainer.execute", return_value=None
-            ) as mock_trainer_exec,
-        ):
-            for pipe_key, path in temp_yaml_files.items():
-                args = ["exec_pipeline", f"--config-path={path}", f"pipe_key={pipe_key}"]
-                monkeypatch.setattr(sys, "argv", args)
+    with (
+        patch(
+            "itwinai.tests.dummy_components.FakePreproc.__init__", return_value=None
+        ) as mock_preproc_init,
+        patch(
+            "itwinai.tests.dummy_components.FakePreproc.execute", return_value=None
+        ) as mock_preproc_exec,
+        patch(
+            "itwinai.tests.dummy_components.FakeTrainer.__init__", return_value=None
+        ) as mock_trainer_init,
+        patch(
+            "itwinai.tests.dummy_components.FakeTrainer.execute", return_value=None
+        ) as mock_trainer_exec,
+    ):
+        path = temp_yaml_files[pipe_key]
+        args = [
+            "exec_pipeline",
+            f"--config-dir={path.parent}",
+            f"--config-path={path.parent}",
+            f"--config-name={path.stem}",
+            f"+pipe_key={pipe_key}",
+        ]
+        monkeypatch.setattr(sys, "argv", args)
 
-                exec_pipeline()
+        exec_pipeline()
 
-                mock_preproc_init.assert_called_once_with(max_items=33, name="my-preproc")
-                mock_preproc_exec.assert_called_once()
+        mock_preproc_init.assert_called_once_with(max_items=33, name="my-preproc")
+        mock_preproc_exec.assert_called_once()
 
-                mock_trainer_init.assert_called_once_with(
-                    lr=0.001, batch_size=32, name="my-trainer"
-                )
-                mock_trainer_exec.assert_called_once()
+        mock_trainer_init.assert_called_once_with(lr=0.001, batch_size=32, name="my-trainer")
+        mock_trainer_exec.assert_called_once()
 
 
-def test_step_selection(temp_yaml_files, monkeypatch):
+@pytest.mark.parametrize(
+    "pipe_key",
+    [
+        "my-list-pipeline",
+        "my-dict-pipeline",
+        "some.field.my-nested-pipeline",
+        "my-interpolation-pipeline",
+    ],
+)
+def test_step_selection(pipe_key, temp_yaml_files, monkeypatch):
     """Test that exec_pipeline can correctly select steps via cli arguments and instantiate
     and execute only the selected steps from the pipeline."""
-    with pytest.raises(SystemExit):
-        with (
-            patch(
-                "itwinai.tests.dummy_components.FakePreproc.__init__", return_value=None
-            ) as mock_preproc_init,
-            patch(
-                "itwinai.tests.dummy_components.FakePreproc.execute", return_value=None
-            ) as mock_preproc_exec,
-            patch(
-                "itwinai.tests.dummy_components.FakeTrainer.__init__", return_value=None
-            ) as mock_trainer_init,
-            patch(
-                "itwinai.tests.dummy_components.FakeTrainer.execute", return_value=None
-            ) as mock_trainer_exec,
-        ):
-            for pipe_key, path in temp_yaml_files.items():
-                args = [
-                    "exec_pipeline",
-                    f"--config-path={path}",
-                    f"pipe_key={pipe_key}",
-                    "+pipe_steps=[1]",
-                ]
-                monkeypatch.setattr(sys, "argv", args)
+    with (
+        patch(
+            "itwinai.tests.dummy_components.FakePreproc.__init__", return_value=None
+        ) as mock_preproc_init,
+        patch(
+            "itwinai.tests.dummy_components.FakePreproc.execute", return_value=None
+        ) as mock_preproc_exec,
+        patch(
+            "itwinai.tests.dummy_components.FakeTrainer.__init__", return_value=None
+        ) as mock_trainer_init,
+        patch(
+            "itwinai.tests.dummy_components.FakeTrainer.execute", return_value=None
+        ) as mock_trainer_exec,
+    ):
+        path = temp_yaml_files[pipe_key]
+        args = [
+            "exec_pipeline",
+            f"--config-dir={path.parent}",
+            f"--config-path={path.parent}",
+            f"--config-name={path.stem}",
+            f"+pipe_key={pipe_key}",
+            "+pipe_steps=[1]",
+        ]
+        monkeypatch.setattr(sys, "argv", args)
 
-                exec_pipeline()
+        exec_pipeline()
 
-                mock_preproc_init.assert_called_once_with(max_items=33, name="my-preproc")
-                mock_preproc_exec.assert_called_once()
+        mock_preproc_init.assert_called_once_with(max_items=33, name="my-preproc")
+        mock_preproc_exec.assert_called_once()
 
-                mock_trainer_init.assert_not_called()
-                mock_trainer_exec.assert_not_called()
+        mock_trainer_init.assert_not_called()
+        mock_trainer_exec.assert_not_called()
+
 
 
 def test_dynamic_override_interpolation_list_pipeline(temp_yaml_files, monkeypatch):
     """Test that exec_pipeline can correctly set keys via cli override and instantiate
     and execute the steps with the updated arguments. This tests the list pipeline with
     interpolation keys."""
-    with pytest.raises(SystemExit):
-        with patch(
+    with (
+        pytest.raises(SystemExit) as sys_exit,
+        patch(
             "itwinai.tests.dummy_components.FakeTrainer.__init__", return_value=None
-        ) as mock_trainer_init:
-            args = [
-                f"--config-path={temp_yaml_files['my-interpolation-pipeline']}",
-                "pipe_key=my-interpolation-pipeline",
-                "lr=0.005",
-                "my-interpolation-pipeline.steps.1.batch_size=64",
-            ]
-            args = [
-                "exec_pipeline",
-                f"--config-path={temp_yaml_files['my-interpolation-pipeline']}",
-                "pipe_key=my-interpolation-pipeline",
-                "lr=0.005",
-                "my-interpolation-pipeline.steps.1.batch_size=64",
-            ]
-            monkeypatch.setattr(sys, "argv", args)
-            exec_pipeline()
+        ) as mock_trainer_init,
+    ):
+        pipe_key = 'my-interpolation-pipeline'
+        path = temp_yaml_files[pipe_key]
 
-            mock_trainer_init.assert_called_once_with(
-                lr=0.005, batch_size=64, name="my-trainer"
-            )
+        args = [
+            "exec_pipeline",
+            f"--config-path={path.parent}",
+            f"--config-dir={path.parent}",
+            f"pipe_key={pipe_key}",
+            "lr=0.005",
+            "my-interpolation-pipeline.steps.1.batch_size=64",
+        ]
+        monkeypatch.setattr(sys, "argv", args)
+        exec_pipeline()
+
+        mock_trainer_init.assert_called_once_with(lr=0.005, batch_size=64, name="my-trainer")
+    assert sys_exit.value.code == 0, "Pipeline should run through without fail"
 
 
 def test_dynamic_override_cli_dict_pipeline(temp_yaml_files, monkeypatch):
     """Test that exec_pipeline can correctly set keys via cli override and instantiate
     and execute the steps with the updated arguments. This tests the dictionary pipeline."""
-    with pytest.raises(SystemExit):
-        with patch(
+    with (
+        pytest.raises(SystemExit) as sys_exit,
+        patch(
             "itwinai.tests.dummy_components.FakePreproc.__init__", return_value=None
-        ) as mock_preproc_init:
-            args = [
-                "exec_pipeline",
-                f"--config-path={temp_yaml_files['my-dict-pipeline']}",
-                "pipe_key=my-dict-pipeline",
-                "my-dict-pipeline.steps.preproc-step.name=new-preproc",
-            ]
-            monkeypatch.setattr(sys, "argv", args)
-            exec_pipeline()
+        ) as mock_preproc_init,
+    ):
+        args = [
+            "exec_pipeline",
+            f"--config-path={temp_yaml_files['my-dict-pipeline']}",
+            "pipe_key=my-dict-pipeline",
+            "my-dict-pipeline.steps.preproc-step.name=new-preproc",
+        ]
+        monkeypatch.setattr(sys, "argv", args)
+        exec_pipeline()
 
-            mock_preproc_init.assert_called_once_with(max_items=33, name="new-preproc")
+        mock_preproc_init.assert_called_once_with(max_items=33, name="new-preproc")
+    assert sys_exit.value.code == 0, "Pipeline should run through without fail"
 
 
 def test_invalid_step_selection(temp_yaml_files, monkeypatch):
@@ -168,9 +193,9 @@ def test_invalid_step_selection(temp_yaml_files, monkeypatch):
     ]
     monkeypatch.setattr(sys, "argv", args)
 
-    with pytest.raises(SystemExit):
-        with pytest.raises(errors.ConfigKeyError):
-            exec_pipeline()
+    with pytest.raises(SystemExit) as sys_exit:
+        exec_pipeline()
+    assert sys_exit.value.code == 1, "Expected this to fail"
 
 
 def test_invalid_pipeline_key(temp_yaml_files, monkeypatch):
@@ -182,6 +207,6 @@ def test_invalid_pipeline_key(temp_yaml_files, monkeypatch):
     ]
     monkeypatch.setattr(sys, "argv", args)
 
-    with pytest.raises(SystemExit):
-        with pytest.raises(errors.MissingMandatoryValue):
-            exec_pipeline()
+    with pytest.raises(SystemExit) as sys_exit:
+        exec_pipeline()
+    assert sys_exit.value.code == 1, "Expected this to fail"

--- a/tests/components/test_config_parsing.py
+++ b/tests/components/test_config_parsing.py
@@ -13,7 +13,6 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-from omegaconf import errors
 
 from itwinai.cli import exec_pipeline
 


### PR DESCRIPTION
Sometimes, `exec-pipeline` gives some rather cryptic errors if you use it incorrectly. This PR changes how these errors are handled by using `raise typer.Exit(1)` for error handling as well as adding more checks and thus more comprehensive error message. 

Additionally, the tests written for the config parser are completely wrong on several accounts. First of all, they use `with raise SystemExit`, which apparently captures the program crashing, meaning that the tests don't do anything. Second, they use for loops instead of `pytest.parametrize`, meaning that you have one huge test instead of separate tests. Thirdly, the config that is given to the `exec-pipeline` command doesn't work, so the tests never actually tested anything since they never got far enough to actually do any of the functionality. There were considerably more mistakes than these, but I will omit them for the sake of brevity... This is also fixed in this PR. 

Related issues: #352 