### PR TITLE
Add environment variable for supporting different hpc systems

### DIFF
--- a/src/itwinai/cli.py
+++ b/src/itwinai/cli.py
@@ -504,6 +504,13 @@ def generate_slurm(
         bool,
         typer.Option("--debug", help="Whether to include debugging information or not"),
     ] = False,
+    use_infiniband_suffix: Annotated[
+        bool,
+        typer.Option(
+            "--use-infiniband-suffix",
+            help="Whether to use the infiniband suffix, i.e. {master_addr}i:{port}.",
+        ),
+    ] = False,
     no_save_script: Annotated[
         bool,
         typer.Option(

--- a/src/itwinai/slurm/utils.py
+++ b/src/itwinai/slurm/utils.py
@@ -72,6 +72,7 @@ def get_slurm_job_parser() -> ArgumentParser:
     default_python_venv = ".venv"
     default_scalability_nodes = "1,2,4,8"
     default_profiling_sampling_rate = 10  # py-spy profiler sample rate/frequency
+    default_use_infiniband_suffix = False
 
     parser = ArgumentParser(parser_mode="omegaconf")
 
@@ -188,6 +189,13 @@ def get_slurm_job_parser() -> ArgumentParser:
         type=int,
         default=default_profiling_sampling_rate,
         help="The rate at which the py-spy profiler should sample the call stack.",
+    )
+    parser.add_argument(
+        "-ib",
+        "--use-infiniband-suffix",
+        type=bool,
+        default=default_use_infiniband_suffix,
+        help="Whether to use the infiniband suffix, i.e. {master_addr}i:{port}.",
     )
 
     # Boolean arguments where you only need to include the flag and not an actual value

--- a/use-cases/mnist/torch/slurm_config.yaml
+++ b/use-cases/mnist/torch/slurm_config.yaml
@@ -7,6 +7,7 @@ pipe_key: training_pipeline
 
 py_spy: true
 profiling_sampling_rate: 100
+use_infiniband_suffix: false
 
 training_cmd: "$(which itwinai) exec-pipeline \
   strategy={dist_strat} \


### PR DESCRIPTION
This PR adds the option to set an environment variable that will be used for loading modules etc. This way, you could just export the env variable before running and it would always use the modules relevant to your system. Since it is a string, you could also set it to other things, if your system requires it. For simplicity, you could even add it to your `.bashrc` on the system and never think about it again