### PR TITLE
Fix radio tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,9 +1,11 @@
 name: Testing with pytest
 
-on:
-  pull_request:
-    branches: [main, dev]
-
+# on:
+#   pull_request:
+#     branches: [main, dev]
+on: 
+  push: 
+  
 jobs:
   test-torch:
     name: Testing with pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,11 +1,9 @@
 name: Testing with pytest
 
-# on:
-#   pull_request:
-#     branches: [main, dev]
-on: 
-  push: 
-  
+on:
+  pull_request:
+    branches: [main, dev]
+
 jobs:
   test-torch:
     name: Testing with pytest
@@ -44,7 +42,7 @@ jobs:
             --context ..
             --dockerfile ../env-files/torch/skinny.Dockerfile
             test-local
-            --cmd "pytest,-vs,--disable-warnings,-n,logical,/app/tests/use-cases/test_radio_astronomy.py,--dist,loadfile,-m,not hpc and not tensorflow"
+            --cmd "pytest,-v,--disable-warnings,-n,logical,/app/tests/,--dist,loadfile,-m,not hpc and not tensorflow"
             logs
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           version: latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,7 +44,7 @@ jobs:
             --context ..
             --dockerfile ../env-files/torch/skinny.Dockerfile
             test-local
-            --cmd "pytest,-v,--disable-warnings,-n,logical,/app/tests/,--dist,loadfile,-m,not hpc and not tensorflow"
+            --cmd "pytest,-vs,--disable-warnings,-n,logical,/app/tests/use-cases/test_radio_astronomy.py,--dist,loadfile,-m,not hpc and not tensorflow"
             logs
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           version: latest

--- a/tests/use-cases/test_radio_astronomy.py
+++ b/tests/use-cases/test_radio_astronomy.py
@@ -65,9 +65,8 @@ def generate_unet(torch_env, syndata):
 
     subprocess.run(cmd.split(), check=True, cwd=syndata)
 
-# @pytest.mark.skip(reason="dependent on .test_dataset, incoroporated into integration test")
-@pytest.mark.functional
-# @pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
+@pytest.mark.skip(reason="dependent on .test_dataset, incoroporated as a fixture\
+                                                         into integration test")
 def test_radio_astronomy_unet(torch_env, syndata, install_requirements):
     """Test U-Net Pulsar-DDT trainer by running it end-to-end
     via the config-test.yaml configuration file."""
@@ -82,7 +81,6 @@ def test_radio_astronomy_unet(torch_env, syndata, install_requirements):
     subprocess.run(cmd.split(), check=True, cwd=syndata)
 
 @pytest.mark.functional
-# @pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
 def test_radio_astronomy_filtercnn(torch_env, syndata, generate_unet, install_requirements):
     """Test Filter-CNN Pulsar-DDT trainer by running it end-to-end
     via the config-test.yaml configuration file. Requires the U-Net model to be present."""
@@ -97,7 +95,6 @@ def test_radio_astronomy_filtercnn(torch_env, syndata, generate_unet, install_re
     subprocess.run(cmd.split(), check=True, cwd=syndata)
 
 @pytest.mark.functional
-# @pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
 def test_radio_astronomy_cnn1d(torch_env, syndata, install_requirements):
     """Test CNN-1D Pulsar-DDT trainer by running it end-to-end
     via the config-test.yaml configuration file."""
@@ -111,8 +108,7 @@ def test_radio_astronomy_cnn1d(torch_env, syndata, install_requirements):
 
     subprocess.run(cmd.split(), check=True, cwd=syndata)
 
-# @pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
-@pytest.mark.functional
+@pytest.mark.skip(reason="Requires all moodels to be saved to disk.")
 def test_radio_astronomy_evaluate(torch_env):
     """Test the evaluate pipeline by running it end-to-end
     via the config-test.yaml configuration file."""

--- a/tests/use-cases/test_radio_astronomy.py
+++ b/tests/use-cases/test_radio_astronomy.py
@@ -65,7 +65,7 @@ def generate_unet(torch_env, syndata):
 
 # @pytest.mark.skip(reason="dependent on .test_dataset, incoroporated into integration test")
 @pytest.mark.functional
-@pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
+# @pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
 def test_radio_astronomy_unet(torch_env, syndata, install_requirements):
     """Test U-Net Pulsar-DDT trainer by running it end-to-end
     via the config-test.yaml configuration file."""
@@ -80,7 +80,7 @@ def test_radio_astronomy_unet(torch_env, syndata, install_requirements):
     subprocess.run(cmd.split(), check=True, cwd=syndata)
 
 @pytest.mark.functional
-@pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
+# @pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
 def test_radio_astronomy_filtercnn(torch_env, syndata, generate_unet, install_requirements):
     """Test Filter-CNN Pulsar-DDT trainer by running it end-to-end
     via the config-test.yaml configuration file. Requires the U-Net model to be present."""
@@ -95,7 +95,7 @@ def test_radio_astronomy_filtercnn(torch_env, syndata, generate_unet, install_re
     subprocess.run(cmd.split(), check=True, cwd=syndata)
 
 @pytest.mark.functional
-@pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
+# @pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
 def test_radio_astronomy_cnn1d(torch_env, syndata, install_requirements):
     """Test CNN-1D Pulsar-DDT trainer by running it end-to-end
     via the config-test.yaml configuration file."""
@@ -109,7 +109,7 @@ def test_radio_astronomy_cnn1d(torch_env, syndata, install_requirements):
 
     subprocess.run(cmd.split(), check=True, cwd=syndata)
 
-@pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
+# @pytest.mark.skip(reason="Seems to cause OOM error, halting the other tests.")
 @pytest.mark.functional
 def test_radio_astronomy_evaluate(torch_env):
     """Test the evaluate pipeline by running it end-to-end

--- a/tests/use-cases/test_radio_astronomy.py
+++ b/tests/use-cases/test_radio_astronomy.py
@@ -49,6 +49,8 @@ def syndata(tmp_path, torch_env,install_requirements):
         shutil.copy(USECASE_FOLDER / "data.py", tmp_path)
         shutil.copy(USECASE_FOLDER / "trainer.py", tmp_path)
 
+        print(f"Running synthetic data generation command: {cmd_data}")
+        
         subprocess.run(cmd_data.split(), check=True, cwd=tmp_path)
 
     return tmp_path

--- a/tests/use-cases/test_radio_astronomy.py
+++ b/tests/use-cases/test_radio_astronomy.py
@@ -65,8 +65,7 @@ def generate_unet(torch_env, syndata):
 
     subprocess.run(cmd.split(), check=True, cwd=syndata)
 
-@pytest.mark.skip(reason="dependent on .test_dataset, incoroporated as a fixture\
-                                                         into integration test")
+@pytest.mark.skip(reason="not enough resources in the CI container to run this test")
 def test_radio_astronomy_unet(torch_env, syndata, install_requirements):
     """Test U-Net Pulsar-DDT trainer by running it end-to-end
     via the config-test.yaml configuration file."""
@@ -80,7 +79,8 @@ def test_radio_astronomy_unet(torch_env, syndata, install_requirements):
 
     subprocess.run(cmd.split(), check=True, cwd=syndata)
 
-@pytest.mark.functional
+# @pytest.mark.functional
+@pytest.mark.skip(reason="not enough resources in the CI container to run this test")
 def test_radio_astronomy_filtercnn(torch_env, syndata, generate_unet, install_requirements):
     """Test Filter-CNN Pulsar-DDT trainer by running it end-to-end
     via the config-test.yaml configuration file. Requires the U-Net model to be present."""
@@ -94,7 +94,7 @@ def test_radio_astronomy_filtercnn(torch_env, syndata, generate_unet, install_re
 
     subprocess.run(cmd.split(), check=True, cwd=syndata)
 
-@pytest.mark.functional
+@pytest.mark.skip(reason="not enough resources in the CI container to run this test")
 def test_radio_astronomy_cnn1d(torch_env, syndata, install_requirements):
     """Test CNN-1D Pulsar-DDT trainer by running it end-to-end
     via the config-test.yaml configuration file."""

--- a/use-cases/radio-astronomy/data.py
+++ b/use-cases/radio-astronomy/data.py
@@ -64,8 +64,8 @@ class SynthesizeData(DataGetter):
         Relies on the pulsar_simulation package."""
 
         # Ray is assumed to be running for the data generation.
-        ray.shutdown() 
-        ray.init(num_cpus=self.parameters["num_cpus"], include_dashboard=False)
+        print(ray.is_initialized())
+        ray.init(num_cpus=self.parameters["num_cpus"], address=”auto”)
         # if ray.is_initialized() == False: ray.init(num_cpus=self.parameters["num_cpus"],
                                                 #    include_dashboard=False)
         generate_example_payloads_for_training(

--- a/use-cases/radio-astronomy/data.py
+++ b/use-cases/radio-astronomy/data.py
@@ -64,8 +64,8 @@ class SynthesizeData(DataGetter):
         Relies on the pulsar_simulation package."""
 
         # Ray is assumed to be running for the data generation.
-        print(ray.is_initialized())
-        ray.init(num_cpus=self.parameters["num_cpus"], address=”auto”)
+        ray.shutdown() 
+        ray.init(num_cpus=self.parameters["num_cpus"], include_dashboard=False)
         # if ray.is_initialized() == False: ray.init(num_cpus=self.parameters["num_cpus"],
                                                 #    include_dashboard=False)
         generate_example_payloads_for_training(

--- a/use-cases/radio-astronomy/data.py
+++ b/use-cases/radio-astronomy/data.py
@@ -63,9 +63,11 @@ class SynthesizeData(DataGetter):
         """Generate synthetic data and save it to disk.
         Relies on the pulsar_simulation package."""
 
-        # Ray is assumed to be running for the data generation. 
-        if ray.is_initialized() == False: ray.init(num_cpus=self.parameters["num_cpus"],
-                                                   include_dashboard=False)
+        # Ray is assumed to be running for the data generation.
+        ray.shutdown() 
+        ray.init(num_cpus=self.parameters["num_cpus"], include_dashboard=False)
+        # if ray.is_initialized() == False: ray.init(num_cpus=self.parameters["num_cpus"],
+                                                #    include_dashboard=False)
         generate_example_payloads_for_training(
             tag=self.parameters["tag"],
             num_payloads=self.parameters["num_payloads"],
@@ -75,7 +77,8 @@ class SynthesizeData(DataGetter):
             num_cpus=self.parameters["num_cpus"],
             reinit_ray=False,
         )
-        if ray.is_initialized(): ray.shutdown()  # shutdown ray after the data generation is done
+        ray.shutdown() 
+        # if ray.is_initialized(): ray.shutdown()  # shutdown ray after the data generation is done
 
 
 class PulsarDataset(Dataset):

--- a/use-cases/radio-astronomy/data.py
+++ b/use-cases/radio-astronomy/data.py
@@ -64,7 +64,8 @@ class SynthesizeData(DataGetter):
         Relies on the pulsar_simulation package."""
 
         # Ray is assumed to be running for the data generation. 
-        if ray.is_initialized() == False: ray.init(num_cpus=self.parameters["num_cpus"])
+        if ray.is_initialized() == False: ray.init(num_cpus=self.parameters["num_cpus"],
+                                                   include_dashboard=False)
         generate_example_payloads_for_training(
             tag=self.parameters["tag"],
             num_payloads=self.parameters["num_payloads"],

--- a/use-cases/radio-astronomy/data.py
+++ b/use-cases/radio-astronomy/data.py
@@ -27,6 +27,7 @@ from pulsar_analysis.pipeline_methods import (
 )
 from pulsar_analysis.neural_network_models import UNet
 from pulsar_simulation.generate_data_pipeline import generate_example_payloads_for_training
+import ray
 
 class SynthesizeData(DataGetter):
     def __init__(
@@ -61,6 +62,9 @@ class SynthesizeData(DataGetter):
     def execute(self) -> None:
         """Generate synthetic data and save it to disk.
         Relies on the pulsar_simulation package."""
+
+        # Ray is assumed to be running for the data generation. 
+        if ray.is_initialized() == False: ray.init(num_cpus=self.parameters["num_cpus"])
         generate_example_payloads_for_training(
             tag=self.parameters["tag"],
             num_payloads=self.parameters["num_payloads"],
@@ -70,6 +74,7 @@ class SynthesizeData(DataGetter):
             num_cpus=self.parameters["num_cpus"],
             reinit_ray=False,
         )
+        if ray.is_initialized(): ray.shutdown()  # shutdown ray after the data generation is done
 
 
 class PulsarDataset(Dataset):

--- a/use-cases/radio-astronomy/data.py
+++ b/use-cases/radio-astronomy/data.py
@@ -63,11 +63,9 @@ class SynthesizeData(DataGetter):
         """Generate synthetic data and save it to disk.
         Relies on the pulsar_simulation package."""
 
-        # Ray is assumed to be running for the data generation.
-        ray.shutdown() 
-        ray.init(num_cpus=self.parameters["num_cpus"], include_dashboard=False)
-        # if ray.is_initialized() == False: ray.init(num_cpus=self.parameters["num_cpus"],
-                                                #    include_dashboard=False)
+        # Ray is assumed to be running for the data generation. 
+        if ray.is_initialized() == False: ray.init(num_cpus=self.parameters["num_cpus"],
+                                                   include_dashboard=False)
         generate_example_payloads_for_training(
             tag=self.parameters["tag"],
             num_payloads=self.parameters["num_payloads"],
@@ -77,8 +75,7 @@ class SynthesizeData(DataGetter):
             num_cpus=self.parameters["num_cpus"],
             reinit_ray=False,
         )
-        ray.shutdown() 
-        # if ray.is_initialized(): ray.shutdown()  # shutdown ray after the data generation is done
+        if ray.is_initialized(): ray.shutdown()  # shutdown ray after the data generation is done
 
 
 class PulsarDataset(Dataset):


### PR DESCRIPTION
I've turned off the ray dashboard for the synthetic data generation. In the container, when running the pytest pipeline for the use-cases, it would attempt to create a ray dashboard and crash Ray without killing the job. Disabling the dashboard fixes the problem for me locally (Macbook) and on Juwels Booster, but the container likely doesn't have enough RAM to execute the job either way. So I'll leave the tests disabled, but look into an alternative GH testing pipeline that can be executed on Juwels Booster with sufficient resources.