### PR TITLE
Initial set-up for the runner

### DIFF
--- a/.github/workflows/juwels-runner.yml
+++ b/.github/workflows/juwels-runner.yml
@@ -1,0 +1,58 @@
+name: Test Juwels Runner
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  run-command:
+    runs-on: [self-hosted, linux]  # adjust labels if you used custom ones
+    env:
+      GITHUB_WORKSPACE: /p/project1/intertwin/krochak1/itwinai
+      SLURM_SCRIPT: /p/project1/intertwin/krochak1/itwinai/test.sh
+      SLURM_LOGS: /p/project1/intertwin/krochak1/itwinai/pytest-runner/actions-runner-logs
+      
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Submit and monitor SLURM job
+        run: |
+          
+          cd $GITHUB_WORKSPACE || exit 
+
+          echo "Submitting job..."
+          JOBID=$(sbatch --parsable "$SLURM_SCRIPT")
+          echo "Submitted as $JOBID"
+          echo "JOBID=$JOBID" >> $GITHUB_ENV
+
+          echo "Waiting for job to complete..."
+          while squeue -j "$JOBID" 2>/dev/null | grep -q "$JOBID"; do
+            sleep 10
+          done
+
+          echo "Job $JOBID appears to have finished."
+
+          echo "Querying SLURM exit code..."
+          EXIT_CODE=$(sacct -j "${JOBID}.batch" --format=ExitCode -n | awk '{print $1}' | cut -d':' -f1)
+
+          if [[ -z "$EXIT_CODE" ]]; then
+            echo "ERROR: Could not retrieve exit code from sacct."
+            exit 1
+          fi
+
+          if [[ "$EXIT_CODE" -ne 0 ]]; then
+            echo "SLURM job failed with exit code $EXIT_CODE"
+            exit 1
+          else
+            echo "SLURM job completed successfully with exit code 0"
+          fi
+
+      - name: Read SLURM logs 
+        run: |
+          echo "=== SLURM STDOUT ==="
+          cat "${SLURM_LOGS}/output.${JOBID}.out" || echo "No output file found."
+
+          echo "=== SLURM STDERR ==="
+          cat "${SLURM_LOGS}/error.${JOBID}.out" || echo "No error file found."

--- a/pytest-runner/kill_runner.sh
+++ b/pytest-runner/kill_runner.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+stop_pid() {
+  local name=$1
+  local file=$2
+
+  if [ -f "$file" ]; then
+    local pid
+    pid=$(cat "$file")
+    if ps -p "$pid" > /dev/null 2>&1; then
+      kill "$pid" && echo "Stopped $name (PID: $pid)"
+    else
+      echo "$name not running."
+    fi
+    rm -f "$file"
+  else
+    echo "No $name PID file found."
+  fi
+}
+
+stop_pid "Runner.Listener" "runner-listener.pid"
+stop_pid "helper script" "runner-helper.pid"

--- a/pytest-runner/monitor_runner.sh
+++ b/pytest-runner/monitor_runner.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+check_pid() {
+  local name=$1
+  local file=$2
+
+  if [ -f "$file" ]; then
+    local pid
+    pid=$(cat "$file")
+    if ps -p "$pid" > /dev/null 2>&1; then
+      echo "$name is running (PID: $pid)"
+      return 0
+    else
+      echo "$name not running."
+      return 1
+    fi
+  else
+    echo "No $name PID file found."
+    return 1
+  fi
+}
+
+# Check for the helper script existence
+check_pid "Helper script" "runner-helper.pid"
+helper_status=$?
+
+# Check for the listener script existence
+check_pid "Runner.Listener" "runner-listener.pid"
+listener_status=$?
+
+# Return exit status
+exit $(( helper_status != 0 || listener_status != 0 ))

--- a/pytest-runner/start_runner.sh
+++ b/pytest-runner/start_runner.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+LOGFILE="log"
+RUNNER_DIR="/p/project1/intertwin/krochak1/actions-runner"
+HELPER="$RUNNER_DIR/run.sh"
+
+# launch the runner, get PID and write it file
+rm -f "$LOGFILE"
+nohup "$HELPER" > "$LOGFILE" 2>&1 &
+HELPER_PID=$!
+echo $HELPER_PID > runner-helper.pid
+disown
+
+# Wait briefly to allow Runner.Listener to start
+sleep 2
+
+# Get the PID of Runner.Listener via pgrep
+LISTENER_PID=$(pgrep -f "$RUNNER_DIR/bin/Runner.Listener run")
+if [ -n "$LISTENER_PID" ]; then
+  echo "$LISTENER_PID" > runner-listener.pid
+else
+  echo "ERROR: Runner.Listener process not found."
+  rm -f runner-helper.pid
+  exit 1
+fi
+
+echo "Runner started."
+echo "Helper PID: $HELPER_PID"
+echo "Listener PID: $LISTENER_PID"

--- a/pytest.sh
+++ b/pytest.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## general configuration of the job
+#SBATCH --job-name=itwinai-radio-astronomy
+#SBATCH --account=slfse
+#SBATCH --partition=devel
+#SBATCH --output=/p/project1/intertwin/krochak1/pulsar-plugin/pytest-runner/actions-runner-logs/output.%j.out
+#SBATCH --error=/p/project1/intertwin/krochak1/pulsar-plugin/pytest-runner/actions-runner-logs/error.%j.out
+#SBATCH --time=00:10:00
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=48
+
+ml --force purge
+ml Stages/2024 GCC OpenMPI CUDA/12 cuDNN MPI-settings/CUDA
+ml Python CMake HDF5 PnetCDF libaio mpi4py
+ml X11/20230603 OpenGL/2023a
+
+#shellcheck disable=SC1091
+source /p/project1/intertwin/krochak1/pulsar-plugin/.venv-juwels-cluster/bin/activate
+
+cd /p/project1/intertwin/krochak1/pulsar-plugin || exit
+pytest tests


### PR DESCRIPTION
<!--
This pull request will allow an alternative testing environment, namely the self-hosted GitHub actions runner on Juwels Booster machine. The runner is running on a login node and is located in intertwin project space. It submits SLURM jobs on request that execute the pytest suite. This way, there is virtually no limit on the resources used during the testings, and realistic tests can be executed for itwinai use-cases. 
-->

Ideally, the status of the runner should be monitored with itwinai commands. 

The output of SLURM job is parsed via the runner and can be read on GitHub actions log directly, which is in accordance to open-source principles in contrast to currently employed Dagger container runner which requires explicit access to read the error logs. 