### PR TITLE
Fix the syntax in the Vega pre-execution script so that it works with containers. 

### DIFF
--- a/src/itwinai/slurm/system-base-scripts/vega_pre_exec.sh
+++ b/src/itwinai/slurm/system-base-scripts/vega_pre_exec.sh
@@ -63,7 +63,7 @@ function torchrun-launcher(){
     --rdzv_conf=is_host="$(( SLURM_NODEID == 0 ? 1 : 0 ))" \
     --rdzv_backend=c10d \
     --rdzv_endpoint="$MASTER_ADDR":"$MASTER_PORT" \
-    --redirects="$(((SLURM_NODEID)) && echo "3" || echo "1:3,2:3,3:3")" \
+    --redirects="$( $(( SLURM_NODEID )) && echo "3" || echo "1:3,2:3,3:3")" \
     --no-python'
   torchrun_command="$torchrun_command $1"
   srun --cpu-bind=none --ntasks-per-node=1 bash -c "$torchrun_command"
@@ -81,7 +81,7 @@ function torchrun-launcher-container(){
     --rdzv_conf=is_host="$(( SLURM_NODEID == 0 ? 1 : 0 ))" \
     --rdzv_backend=c10d \
     --rdzv_endpoint="$MASTER_ADDR":"$MASTER_PORT" \
-    --redirects="$(((SLURM_NODEID)) && echo "3" || echo "1:3,2:3,3:3")" \
+    --redirects="$( $(( SLURM_NODEID )) && echo "3" || echo "1:3,2:3,3:3")" \
     --no-python'
   torchrun_command="$torchrun_command $1"
   srun --cpu-bind=none --ntasks-per-node=1 "$CONTAINER_PATH" /bin/bash -c "$torchrun_command"


### PR DESCRIPTION
There was a problem with the Vega pre-execution script that made it not work well for containers. Now, after updating the `--redirects` command, it seems to work again. 

In particular: The syntax `$(((` is problematic because what we wanted to do was essentially first open a single parenthesis and then a double, arithmetic one. However, when they were all adjacent, it instead tried to open a double first and then a single, causing some trouble in the evaluation. 