### PR TITLE
Remove Anna's email address from author information

### DIFF
--- a/joss/paper.md
+++ b/joss/paper.md
@@ -22,7 +22,6 @@ authors:
     affiliation: 1
   - given-names: Anna Elisa
     surname: Lappe
-    email: anna.elisa.lappe@cern.ch
     affiliation: 1
     orcid: 0009-0009-4804-4188
   - given-names: Kalliopi


### PR DESCRIPTION
Removed email address for Anna Elisa Lappe.